### PR TITLE
Add deployment instructions and script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,36 @@
+# Automation by Meir
+
+This project is a small demo using PayPal, a Node Express server, and Google Apps Script.
+
+## Serving the site securely
+
+Firebase Hosting automatically provides HTTPS. Deploying the static site there resolves the browser's “Not Secure” warning.
+
+### Prerequisites
+
+- Install Node.js
+- Install the Firebase CLI: `npm install -g firebase-tools`
+- Log in to Firebase and set the default project:
+  ```bash
+  firebase login
+  firebase use --add
+  ```
+  When prompted, select the Firebase project associated with this repo.
+
+### Deployment steps
+
+1. Build the static assets:
+   ```bash
+   npm run build
+   ```
+2. Deploy to Firebase Hosting:
+   ```bash
+   firebase deploy
+   ```
+
+Firebase will host the files in `public/` over HTTPS.
+
+### Optional: deploy the API
+
+If you run the Express API separately, deploy it to a hosting provider that supports TLS, such as Google Cloud Run. Update the `vite.config.js` proxy target to the HTTPS URL of your API.
+

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -e
+npm install
+npm run build
+firebase deploy

--- a/package.json
+++ b/package.json
@@ -4,18 +4,19 @@
   "private": true,
   "type": "module",
   "scripts": {
-      "start": "vite",
-      "server": "node server.js",
-      "build": "vite build",
-      "preview": "vite preview"
+    "start": "vite",
+    "server": "node server.js",
+    "build": "vite build",
+    "preview": "vite preview",
+    "deploy": "npm run build && firebase deploy"
   },
   "dependencies": {
-      "@paypal/paypal-server-sdk": "^1.0.4",
-      "body-parser": "^1.20.2",
-      "dotenv": "^16.4.5",
-      "express": "^4.19.2"
+    "@paypal/paypal-server-sdk": "^1.0.4",
+    "body-parser": "^1.20.2",
+    "dotenv": "^16.4.5",
+    "express": "^4.19.2"
   },
   "devDependencies": {
-      "vite": "^5.4.2"
+    "vite": "^5.4.2"
   }
 }


### PR DESCRIPTION
## Summary
- document how to deploy using Firebase Hosting
- add a `deploy` npm script
- include a helper `deploy.sh` script for convenience

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_687d29cf201c8333b57bc069708750bb