### PR TITLE
feat: unify navigation with showcase dropdown and Hebrew link

### DIFF
--- a/dist/automation-playground.html
+++ b/dist/automation-playground.html
@@ -15,13 +15,29 @@
     <title>Automation Puzzle - Build Your Perfect Workflow</title>
     <style>
         @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap');
+
+        :root {
+            --primary: #00e676;
+            --primary-dark: #00c853;
+            --secondary: #448aff;
+            --dark: #0a0a0a;
+            --dark-secondary: #1a1a1a;
+            --dark-tertiary: #2a2a2a;
+            --light: #ffffff;
+            --text-primary: #e0e0e0;
+            --text-secondary: #9e9e9e;
+            --border-color: #333;
+            --accent: #fbbc04;
+            --danger: #ea4335;
+            --gray: #5f6368;
+        }
         
         * {
             margin: 0;
             padding: 0;
             box-sizing: border-box;
         }
-        
+
         body {
             font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
             background: #000;
@@ -29,9 +45,154 @@
             overflow: hidden;
             position: relative;
         }
-        
+
+        nav {
+            position: fixed;
+            top: 0;
+            width: 100%;
+            background: rgba(10, 10, 10, 0.8);
+            backdrop-filter: blur(10px);
+            z-index: 1000;
+            padding: 1rem 0;
+            border-bottom: 1px solid rgba(51, 51, 51, 0.5);
+        }
+
+        .nav-container {
+            max-width: 1200px;
+            margin: 0 auto;
+            padding: 0 2rem;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+        }
+
+        .logo {
+            display: flex;
+            align-items: center;
+            gap: 0.75rem;
+            text-decoration: none;
+            color: var(--light);
+            font-size: 1.25rem;
+            font-weight: 600;
+        }
+
+        .logo svg {
+            width: 40px;
+            height: 40px;
+            border-radius: 8px;
+            background: var(--dark-secondary);
+            padding: 8px;
+            border: 1px solid var(--border-color);
+        }
+
+        .nav-toggle {
+            display: none;
+        }
+
+        .nav-links {
+            display: flex;
+            list-style: none;
+            gap: 2.5rem;
+            align-items: center;
+        }
+
+        .nav-links li {
+            position: relative;
+        }
+
+        .nav-links a {
+            color: var(--text-secondary);
+            text-decoration: none;
+            font-size: 0.9rem;
+            font-weight: 500;
+            transition: color 0.3s ease;
+            position: relative;
+        }
+
+        .nav-links a:hover {
+            color: var(--light);
+        }
+
+        .nav-links a::after {
+            content: '';
+            position: absolute;
+            bottom: -5px;
+            left: 0;
+            width: 0;
+            height: 2px;
+            background: var(--primary);
+            transition: width 0.3s ease;
+        }
+
+        .nav-links a:hover::after {
+            width: 100%;
+        }
+
+        .dropdown {
+            display: none;
+            flex-direction: column;
+            position: absolute;
+            top: calc(100% + 0.5rem);
+            left: 0;
+            background: var(--dark-secondary);
+            border: 1px solid var(--border-color);
+            padding: 0.5rem 0;
+            border-radius: 8px;
+            min-width: 200px;
+            z-index: 10;
+        }
+
+        .dropdown a {
+            padding: 0.5rem 1.5rem;
+            white-space: nowrap;
+        }
+
+        .dropdown a:hover {
+            background: var(--dark-tertiary);
+        }
+
+        .dropdown.show {
+            display: flex;
+        }
+
+        @media (max-width: 768px) {
+            .nav-links {
+                display: none;
+                position: absolute;
+                top: 100%;
+                right: 0;
+                background: var(--dark);
+                flex-direction: column;
+                padding: 1rem 2rem;
+                border: 1px solid var(--border-color);
+            }
+
+            .nav-links.show {
+                display: flex;
+            }
+
+            .nav-links .dropdown {
+                position: static;
+                background: transparent;
+                border: none;
+                padding: 0;
+            }
+
+            .dropdown a {
+                padding: 0.5rem 0;
+            }
+
+            .nav-toggle {
+                display: block;
+                background: none;
+                border: none;
+                color: var(--light);
+                font-size: 1.5rem;
+                cursor: pointer;
+            }
+        }
+
         /* Background Animation */
-        
         .bg-grid {
             position: fixed;
             top: 0;
@@ -45,14 +206,13 @@
             animation: gridMove 20s linear infinite;
             z-index: -1;
         }
-        
+
         @keyframes gridMove {
             0% { transform: translate(0, 0); }
             100% { transform: translate(50px, 50px); }
         }
-        
+
         /* Floating particles */
-        
         .particle {
             position: absolute;
             background: radial-gradient(circle, rgba(66, 133, 244, 0.8), transparent);
@@ -60,7 +220,7 @@
             pointer-events: none;
             animation: float 15s infinite;
         }
-        
+
         @keyframes float {
             0%, 100% { 
                 transform: translateY(0) translateX(0) scale(1);
@@ -72,18 +232,16 @@
                 transform: translateY(-100vh) translateX(100px) scale(1.5);
             }
         }
-        
+
         /* Main Container */
-        
         .container {
             display: flex;
             height: 100vh;
             position: relative;
             z-index: 1;
         }
-        
+
         /* Service Panel */
-        
         .service-panel {
             width: 300px;
             background: rgba(32, 33, 36, 0.95);
@@ -93,7 +251,7 @@
             overflow-y: auto;
             transition: all 0.3s ease;
         }
-        
+
         .service-panel .panel-header {
             display: flex;
             align-items: center;
@@ -101,25 +259,24 @@
             gap: 0.8rem;
             margin-bottom: 1.5rem;
         }
-        
+
         .service-panel .panel-header svg {
             width: 2.5rem;
             height: 2.5rem;
         }
-        
+
         .service-panel h2 {
             font-size: 1.5rem;
             background: linear-gradient(135deg, #4285F4 0%, #34A853 100%);
             -webkit-background-clip: text;
             -webkit-text-fill-color: transparent;
         }
-        
+
         /* Service Categories */
-        
         .service-category {
             margin-bottom: 2rem;
         }
-        
+
         .category-title {
             font-size: 0.875rem;
             color: #5f6368;
@@ -127,9 +284,8 @@
             text-transform: uppercase;
             letter-spacing: 0.1em;
         }
-        
+
         /* Service Items */
-        
         .service-item {
             background: rgba(45, 45, 48, 0.8);
             border: 1px solid rgba(95, 99, 104, 0.3);
@@ -141,7 +297,7 @@
             position: relative;
             overflow: hidden;
         }
-        
+
         .service-item::before {
             content: '';
             position: absolute;
@@ -154,57 +310,55 @@
             transition: opacity 0.3s ease;
             pointer-events: none;
         }
-        
+
         .service-item:hover {
             transform: translateY(-2px);
             border-color: var(--service-color);
             box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
         }
-        
+
         .service-item:hover::before {
             opacity: 0.1;
         }
-        
+
         .service-item.dragging {
             opacity: 0.5;
             cursor: grabbing;
         }
-        
+
         .service-icon {
             width: 40px;
             height: 40px;
             margin-bottom: 0.5rem;
             filter: drop-shadow(0 2px 4px rgba(0, 0, 0, 0.3));
         }
-        
+
         .service-name {
             font-weight: 600;
             font-size: 0.9rem;
             color: #f8f9fa;
         }
-        
+
         .service-desc {
             font-size: 0.75rem;
             color: #9aa0a6;
             margin-top: 0.25rem;
         }
-        
+
         /* Canvas Area */
-        
         .canvas-area {
             flex: 1;
             position: relative;
             overflow: hidden;
         }
-        
+
         .canvas {
             width: 100%;
             height: 100%;
             position: relative;
         }
-        
+
         /* Connection Lines */
-        
         #connections {
             position: absolute;
             top: 0;
@@ -214,9 +368,8 @@
             pointer-events: none;
             z-index: 1;
         }
-        
+
         /* Dropped Service */
-        
         .dropped-service {
             position: absolute;
             background: rgba(32, 33, 36, 0.95);
@@ -229,7 +382,7 @@
             animation: dropIn 0.5s ease;
             z-index: 10;
         }
-        
+
         @keyframes dropIn {
             0% {
                 transform: scale(0.8) translateY(-20px);
@@ -240,17 +393,17 @@
                 opacity: 1;
             }
         }
-        
+
         .dropped-service:hover {
             transform: scale(1.05);
             box-shadow: 0 12px 48px rgba(0, 0, 0, 0.6);
         }
-        
+
         .dropped-service.selected {
             border-color: #FBBC04;
             box-shadow: 0 0 0 3px rgba(251, 188, 4, 0.3);
         }
-        
+
         .dropped-service .remove-btn {
             position: absolute;
             top: -10px;
@@ -267,14 +420,13 @@
             transition: all 0.3s ease;
             box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
         }
-        
+
         .dropped-service .remove-btn:hover {
             transform: scale(1.2);
             background: #ff5847;
         }
-        
+
         /* Connection Points */
-        
         .connection-point {
             position: absolute;
             width: 16px;
@@ -286,28 +438,27 @@
             transition: all 0.3s ease;
             z-index: 20;
         }
-        
+
         .connection-point.input {
             left: -8px;
             top: 50%;
             transform: translateY(-50%);
             background: #34A853;
         }
-        
+
         .connection-point.output {
             right: -8px;
             top: 50%;
             transform: translateY(-50%);
             background: #FBBC04;
         }
-        
+
         .connection-point:hover {
             transform: translateY(-50%) scale(1.5);
             box-shadow: 0 0 0 4px rgba(66, 133, 244, 0.3);
         }
-        
+
         /* Info Panel */
-        
         .info-panel {
             position: fixed;
             bottom: 2rem;
@@ -320,7 +471,7 @@
             max-width: 300px;
             animation: slideIn 0.5s ease;
         }
-        
+
         @keyframes slideIn {
             from {
                 transform: translateX(100%);
@@ -331,20 +482,20 @@
                 opacity: 1;
             }
         }
-        
+
         .info-panel h3 {
             font-size: 1.2rem;
             margin-bottom: 1rem;
             color: #4285F4;
         }
-        
+
         .stats {
             display: grid;
             grid-template-columns: 1fr 1fr;
             gap: 1rem;
             margin-top: 1rem;
         }
-        
+
         .stat {
             text-align: center;
             padding: 0.75rem;
@@ -352,21 +503,20 @@
             border-radius: 8px;
             border: 1px solid rgba(66, 133, 244, 0.2);
         }
-        
+
         .stat-value {
             font-size: 1.5rem;
             font-weight: 700;
             color: var(--stat-color);
         }
-        
+
         .stat-label {
             font-size: 0.75rem;
             color: #9aa0a6;
             margin-top: 0.25rem;
         }
-        
+
         /* Action Buttons */
-        
         .action-buttons {
             position: fixed;
             top: 2rem;
@@ -375,7 +525,7 @@
             gap: 1rem;
             z-index: 100;
         }
-        
+
         .btn {
             padding: 0.75rem 1.5rem;
             border: none;
@@ -387,31 +537,30 @@
             text-decoration: none;
             display: inline-block;
         }
-        
+
         .btn-primary {
             background: linear-gradient(135deg, #4285F4 0%, #34A853 100%);
             color: white;
             box-shadow: 0 4px 15px rgba(66, 133, 244, 0.3);
         }
-        
+
         .btn-primary:hover {
             transform: translateY(-2px);
             box-shadow: 0 6px 25px rgba(66, 133, 244, 0.5);
         }
-        
+
         .btn-secondary {
             background: rgba(45, 45, 48, 0.8);
             color: #f8f9fa;
             border: 1px solid rgba(95, 99, 104, 0.3);
         }
-        
+
         .btn-secondary:hover {
             background: rgba(60, 60, 60, 0.8);
             border-color: rgba(66, 133, 244, 0.5);
         }
-        
+
         /* Success Animation */
-        
         .success-pulse {
             position: absolute;
             border-radius: 50%;
@@ -419,7 +568,7 @@
             animation: pulse 1s ease-out;
             pointer-events: none;
         }
-        
+
         @keyframes pulse {
             0% {
                 width: 0;
@@ -432,9 +581,8 @@
                 opacity: 0;
             }
         }
-        
+
         /* Mobile Responsive */
-        
         @media (max-width: 768px) {
             .container {
                 flex-direction: column;
@@ -473,6 +621,29 @@
     <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-PZ9XZMFL"
     height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
     <!-- End Google Tag Manager (noscript) -->
+    <nav id="navbar">
+        <div class="nav-container">
+            <a href="index.html" class="logo">
+                <svg viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M40 48H8C5.79086 48 4 46.2091 4 44V4C4 1.79086 5.79086 0 8 0H30L44 14V44C44 46.2091 42.2091 48 40 48Z" fill="#2D2D30"/><path d="M30 0L44 14H34C31.7909 14 30 12.2091 30 10V0Z" fill="#424242"/><path d="M22 26L18 30L22 34" stroke="#448aff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/><path d="M30 26L34 30L30 34" stroke="#00e676" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/><path d="M20 40L24 36L28 40" stroke="#fbbc04" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                Automations <span style="color: var(--text-secondary); font-weight: 400;">BY MEIR</span>
+            </a>
+            <button class="nav-toggle" id="navToggle">☰</button>
+            <ul class="nav-links">
+                <li><a href="index.html#services">Services</a></li>
+                <li><a href="index.html#projects">Projects</a></li>
+                <li><a href="automation-playground.html" class="playground-link">Try It Live</a></li>
+                <li class="submenu"><a href="#">Showcases</a>
+                    <ul class="dropdown">
+                        <li><a href="showcase1.html">Crypto Wallet Tracker</a></li>
+                        <li><a href="showcase2.html">Enterprise Analytics Dashboard</a></li>
+                    </ul>
+                </li>
+                <li><a href="why-automation.html">Why Automate</a></li>
+                <li><a href="index.html#contact">Contact</a></li>
+                <li><a href="index-he.html">עברית</a></li>
+            </ul>
+        </div>
+    </nav>
     <div class="bg-grid"></div>
     
     <!-- Floating Particles -->
@@ -1310,6 +1481,25 @@
 
         // Initialize on load
         createParticles();
+    </script>
+    <script>
+        const navToggle = document.getElementById('navToggle');
+        const navLinks = document.querySelector('.nav-links');
+        const submenu = document.querySelector('.submenu');
+        const submenuLink = document.querySelector('.submenu > a');
+        const dropdown = document.querySelector('.submenu .dropdown');
+        navToggle.addEventListener('click', () => {
+            navLinks.classList.toggle('show');
+        });
+        submenuLink.addEventListener('click', (e) => {
+            e.preventDefault();
+            dropdown.classList.toggle('show');
+        });
+        document.addEventListener('click', (e) => {
+            if (!submenu.contains(e.target)) {
+                dropdown.classList.remove('show');
+            }
+        });
     </script>
 </body>
 </html>

--- a/dist/index-he.html
+++ b/dist/index-he.html
@@ -132,8 +132,6 @@
             .services-grid, .projects-grid, .stats { grid-template-columns: 1fr; }
         }
     </style>
-  <script type="module" crossorigin src="/assets/hebrew-8z1s0cHj.js"></script>
-  <link rel="modulepreload" crossorigin href="/assets/modulepreload-polyfill-B5Qt9EMX.js">
 </head>
 <body>
     <!-- Google Tag Manager (noscript) -->
@@ -328,5 +326,141 @@
     <footer>
         <p>&copy; 2025 Automation by Meir. כל הזכויות שמורות.</p>
     </footer>
+    <script type="module">
+        import { initializeApp } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-app.js";
+        const firebaseConfig = {
+            apiKey: "AIzaSyBDv0d_OVQsHzD_biFpkMvFrXaZguCYG58",
+            authDomain: "automationbymeir.firebaseapp.com",
+            projectId: "automationbymeir",
+            storageBucket: "automationbymeir.firebasestorage.app",
+            messagingSenderId: "216703427811",
+            appId: "1:216703427811:web:a2c848833870a1415c91d6",
+            measurementId: "G-D8GQDGVR08"
+        };
+        const app = initializeApp(firebaseConfig);
+        const SCRIPT_URL = "https://script.google.com/macros/s/AKfycbzYDJcrt8eT52qSQJf6sQ842LyUNjZQm-DGLaM_g757DDdC0viqZSgAyUilmOmxgJ_Cyw/exec";
+        const step1 = document.getElementById('step1');
+        const step2 = document.getElementById('step2');
+        const toStep2Btn = document.getElementById('toStep2');
+        const toStep1Btn = document.getElementById('toStep1');
+        const form = document.getElementById('projectForm');
+        const submitBtn = document.getElementById('submitBtn');
+        const slotsLoader = document.getElementById('slotsLoader');
+        const timeSlotsContainer = document.getElementById('timeSlots');
+        const formMessage = document.getElementById('form-message');
+        let selectedSlot = null;
+        toStep2Btn.addEventListener('click', () => {
+            if (form.checkValidity()) {
+                step1.classList.remove('active');
+                step2.classList.add('active');
+                fetchAvailableSlots();
+            } else {
+                form.reportValidity();
+            }
+        });
+        toStep1Btn.addEventListener('click', () => {
+            step2.classList.remove('active');
+            step1.classList.add('active');
+        });
+        async function fetchAvailableSlots() {
+            slotsLoader.style.display = 'block';
+            timeSlotsContainer.innerHTML = '';
+            try {
+                const response = await fetch(SCRIPT_URL);
+                const data = await response.json();
+                if (data.success) {
+                    displaySlots(data.slots);
+                } else {
+                    throw new Error(data.error || 'Failed to load slots.');
+                }
+            } catch (error) {
+                console.error('Error fetching slots:', error);
+                timeSlotsContainer.innerHTML = `<p style="color: var(--danger);">Could not load available times. Please try again later.</p>`;
+            } finally {
+                slotsLoader.style.display = 'none';
+            }
+        }
+        function displaySlots(slots) {
+            if (slots.length === 0) {
+                timeSlotsContainer.innerHTML = `<p style="color: var(--light);">No available slots in the next 7 days. Please check back later.</p>`;
+                return;
+            }
+            const groupedSlots = slots.reduce((acc, slot) => {
+                const date = new Date(slot);
+                const day = date.toLocaleDateString('he-IL', { weekday: 'long', month: 'long', day: 'numeric' });
+                if (!acc[day]) {
+                    acc[day] = [];
+                }
+                acc[day].push(slot);
+                return acc;
+            }, {});
+            let html = '';
+            for (const day in groupedSlots) {
+                html += `<div style="grid-column: 1 / -1;"><h4 style="color: var(--accent); margin-top: 1rem;">${day}</h4></div>`;
+                groupedSlots[day].forEach(slotISO => {
+                    const time = new Date(slotISO).toLocaleTimeString('he-IL', { hour: '2-digit', minute: '2-digit', hour12: false });
+                    html += `<div class="time-slot" data-value="${slotISO}">${time}</div>`;
+                });
+            }
+            timeSlotsContainer.innerHTML = html;
+        }
+        timeSlotsContainer.addEventListener('click', (e) => {
+            if (e.target.classList.contains('time-slot')) {
+                document.querySelectorAll('.time-slot').forEach(slot => slot.classList.remove('selected'));
+                e.target.classList.add('selected');
+                selectedSlot = e.target.dataset.value;
+            }
+        });
+        form.addEventListener('submit', async (e) => {
+            e.preventDefault();
+            if (!selectedSlot) {
+                alert('נא לבחור שעה.');
+                return;
+            }
+            submitBtn.disabled = true;
+            submitBtn.textContent = 'קובע פגישה...';
+            const formData = new FormData(form);
+            const data = {
+                name: formData.get('name'),
+                email: formData.get('email'),
+                details: formData.get('details'),
+                dateTime: selectedSlot,
+                lang: 'he'
+            };
+            try {
+                await fetch(SCRIPT_URL, {
+                    method: 'POST',
+                    mode: 'no-cors',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify(data)
+                });
+                form.style.display = 'none';
+                formMessage.style.display = 'block';
+                formMessage.className = 'success';
+                formMessage.innerHTML = "<h3>תודה!</h3><p>פגישתך נקבעה. אימייל אישור נשלח אליך.</p>";
+            } catch (error) {
+                console.error('Error submitting form:', error);
+                formMessage.style.display = 'block';
+                formMessage.className = 'error';
+                formMessage.innerHTML = "<h3>שגיאה</h3><p>משהו השתבש. אנא נסה שוב או צור איתי קשר ישירות.</p>";
+                submitBtn.disabled = false;
+                submitBtn.textContent = 'שליחה וקביעת פגישה';
+            }
+        });
+        const navToggle = document.getElementById('navToggle');
+        const navLinks = document.querySelector('.nav-links');
+        navToggle.addEventListener('click', () => {
+            navLinks.classList.toggle('show');
+        });
+
+        window.addEventListener('scroll', () => {
+            const navbar = document.getElementById('navbar');
+            if (window.scrollY > 50) {
+                navbar.classList.add('scrolled');
+            } else {
+                navbar.classList.remove('scrolled');
+            }
+        });
+    </script>
 </body>
 </html>

--- a/dist/index.html
+++ b/dist/index.html
@@ -48,7 +48,6 @@
         }
         
         /* Navigation */
-        
         nav {
             position: fixed;
             top: 0;
@@ -98,6 +97,10 @@
             gap: 2.5rem;
             align-items: center;
         }
+
+        .nav-links li {
+            position: relative;
+        }
         
         .nav-links a {
             color: var(--text-secondary);
@@ -126,9 +129,35 @@
         .nav-links a:hover::after {
             width: 100%;
         }
+
+        .dropdown {
+            display: none;
+            flex-direction: column;
+            position: absolute;
+            top: calc(100% + 0.5rem);
+            left: 0;
+            background: var(--dark-secondary);
+            border: 1px solid var(--border-color);
+            padding: 0.5rem 0;
+            border-radius: 8px;
+            min-width: 200px;
+            z-index: 10;
+        }
+
+        .dropdown a {
+            padding: 0.5rem 1.5rem;
+            white-space: nowrap;
+        }
+
+        .dropdown a:hover {
+            background: var(--dark-tertiary);
+        }
+
+        .dropdown.show {
+            display: flex;
+        }
         
         /* Hero Section */
-        
         .hero {
             min-height: 100vh;
             display: flex;
@@ -142,7 +171,6 @@
         }
         
         /* Wave Net Animation */
-        
         .wave-net {
             position: absolute;
             top: -80px;
@@ -204,7 +232,6 @@
         }
         
         /* Experience Section */
-        
         .experience-section {
             padding: 4rem 2rem;
             background: var(--dark-secondary);
@@ -248,7 +275,6 @@
         }
         
         /* Services Section */
-        
         .services {
             padding: 5rem 2rem;
             background: var(--dark);
@@ -321,7 +347,6 @@
         }
         
         /* Featured Projects */
-        
         .projects {
             padding: 5rem 2rem;
             background: var(--dark-secondary);
@@ -368,7 +393,6 @@
         }
         
         /* About Section */
-        
         .about {
             padding: 5rem 2rem;
             background: var(--dark);
@@ -447,7 +471,6 @@
         }
         
         /* Contact Section */
-        
         .contact {
             padding: 5rem 2rem;
             background: var(--dark-secondary);
@@ -492,7 +515,7 @@
             min-height: 120px;
             resize: vertical;
         }
-        
+
         .btn {
             padding: 1rem 2rem;
             border: none;
@@ -501,40 +524,39 @@
             cursor: pointer;
             transition: all 0.3s ease;
         }
-        
+
         .btn-primary {
             background: var(--primary);
             color: var(--dark);
         }
-        
+
         .btn-primary:hover {
             background: var(--primary-dark);
             transform: translateY(-2px);
         }
-        
+
         .btn-secondary {
             background: transparent;
             color: var(--light);
             border: 2px solid var(--secondary);
         }
-        
+
         .btn-secondary:hover {
             background: var(--secondary);
             color: var(--dark);
             transform: translateY(-2px);
         }
-        
+
         .form-step { display: none; }
-        
         .form-step.active { display: block; }
-        
+
         .time-slots-container {
             display: grid;
             grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
             gap: 1rem;
             margin-top: 1rem;
         }
-        
+
         .time-slot {
             background: var(--dark);
             color: var(--light);
@@ -545,18 +567,18 @@
             transition: all 0.2s ease;
             text-align: center;
         }
-        
+
         .time-slot:hover {
             background: var(--dark-tertiary);
             border-color: var(--primary);
         }
-        
+
         .time-slot.selected {
             background: var(--secondary);
             border-color: var(--secondary);
             color: var(--light);
         }
-        
+
         #form-message {
             margin-top: 1rem;
             padding: 1rem;
@@ -564,17 +586,17 @@
             text-align: center;
             display: none;
         }
-        
+
         #form-message.success {
             background-color: rgba(0, 230, 118, 0.2);
             color: var(--primary);
         }
-        
+
         #form-message.error {
             background-color: rgba(234, 67, 53, 0.2);
             color: var(--danger);
         }
-        
+
         .loader {
             width: 48px;
             height: 48px;
@@ -586,14 +608,13 @@
             animation: rotation 1s linear infinite;
             margin: 2rem auto;
         }
-        
+
         @keyframes rotation {
             0% { transform: rotate(0deg); }
             100% { transform: rotate(360deg); }
         }
         
         /* Footer */
-        
         footer {
             background: var(--dark);
             color: var(--text-secondary);
@@ -603,7 +624,6 @@
         }
         
         /* Responsive */
-        
         @media (max-width: 768px) {
             .nav-links {
                 display: none;
@@ -615,9 +635,20 @@
                 padding: 1rem 2rem;
                 border: 1px solid var(--border-color);
             }
-            
+
             .nav-links.show {
                 display: flex;
+            }
+
+            .nav-links .dropdown {
+                position: static;
+                background: transparent;
+                border: none;
+                padding: 0;
+            }
+
+            .dropdown a {
+                padding: 0.5rem 0;
             }
             
             .nav-toggle {
@@ -649,7 +680,6 @@
         }
         
         /* Animations */
-        
         @keyframes fadeIn {
             from {
                 opacity: 0;
@@ -669,7 +699,6 @@
         }
         
         /* Particle Background */
-        
         .particles {
             position: fixed;
             top: 0;
@@ -699,8 +728,6 @@
             }
         }
     </style>
-  <script type="module" crossorigin src="/assets/main-CAm-l_-v.js"></script>
-  <link rel="modulepreload" crossorigin href="/assets/modulepreload-polyfill-B5Qt9EMX.js">
 </head>
 <body>
     <!-- Particle Background -->
@@ -724,9 +751,15 @@
                 <li><a href="#services">Services</a></li>
                 <li><a href="#projects">Projects</a></li>
                 <li><a href="automation-playground.html" class="playground-link">Try It Live</a></li>
-                <li><a href="#about">Showcases</a></li>
-                <li><a href="#why">Why Automate</a></li>
+                <li class="submenu"><a href="#">Showcases</a>
+                    <ul class="dropdown">
+                        <li><a href="showcase1.html">Crypto Wallet Tracker</a></li>
+                        <li><a href="showcase2.html">Enterprise Analytics Dashboard</a></li>
+                    </ul>
+                </li>
+                <li><a href="why-automation.html">Why Automate</a></li>
                 <li><a href="#contact">Contact</a></li>
+                <li><a href="index-he.html">עברית</a></li>
             </ul>
         </div>
     </nav>
@@ -858,7 +891,7 @@
             <div class="about-content">
                 <div class="about-header">
                     <div class="profile-photo">
-                        <img src="data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPHN2ZyB2aWV3Qm94PSIwIDAgMjAwIDIwMCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KICA8cmVjdCB3aWR0aD0iMjAwIiBoZWlnaHQ9IjIwMCIgZmlsbD0iIzFhMWExYSIvPgogIDxjaXJjbGUgY3g9IjEwMCIgY3k9IjEwMCIgcj0iODAiIGZpbGw9IiMyYTJhMmEiLz4KICA8dGV4dCB4PSIxMDAiIHk9IjExNSIgZm9udC1zaXplPSI2MCIgdGV4dC1hbmNob3I9Im1pZGRsZSIgZmlsbD0iIzlmOWY5ZiIgZm9udC1mYW1pbHk9IkludGVyLCBzYW5zLXNlcmlmIiBmb250LXdlaWdodD0iNjAwIj5NPC90ZXh0Pgo8L3N2Zz4K" alt="Meir" />
+                        <img src="profile.svg" alt="Meir" />
                     </div>
                     <div>
                         <p class="about-text">
@@ -929,6 +962,128 @@
     <footer>
         <p>&copy; 2025 Automations by Meir. All rights reserved.</p>
     </footer>
+    <script type="module">
+        import { initializeApp } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-app.js";
+        const firebaseConfig = {
+            apiKey: "AIzaSyBDv0d_OVQsHzD_biFpkMvFrXaZguCYG58",
+            authDomain: "automationbymeir.firebaseapp.com",
+            projectId: "automationbymeir",
+            storageBucket: "automationbymeir.firebasestorage.app",
+            messagingSenderId: "216703427811",
+            appId: "1:216703427811:web:a2c848833870a1415c91d6",
+            measurementId: "G-D8GQDGVR08"
+        };
+        const app = initializeApp(firebaseConfig);
+        const SCRIPT_URL = "https://script.google.com/macros/s/AKfycbzYDJcrt8eT52qSQJf6sQ842LyUNjZQm-DGLaM_g757DDdC0viqZSgAyUilmOmxgJ_Cyw/exec";
+        const step1 = document.getElementById('step1');
+        const step2 = document.getElementById('step2');
+        const toStep2Btn = document.getElementById('toStep2');
+        const toStep1Btn = document.getElementById('toStep1');
+        const form = document.getElementById('projectForm');
+        const submitBtn = document.getElementById('submitBtn');
+        const slotsLoader = document.getElementById('slotsLoader');
+        const timeSlotsContainer = document.getElementById('timeSlots');
+        const formMessage = document.getElementById('form-message');
+        let selectedSlot = null;
+        toStep2Btn.addEventListener('click', () => {
+            if (form.checkValidity()) {
+                step1.classList.remove('active');
+                step2.classList.add('active');
+                fetchAvailableSlots();
+            } else {
+                form.reportValidity();
+            }
+        });
+        toStep1Btn.addEventListener('click', () => {
+            step2.classList.remove('active');
+            step1.classList.add('active');
+        });
+        async function fetchAvailableSlots() {
+            slotsLoader.style.display = 'block';
+            timeSlotsContainer.innerHTML = '';
+            try {
+                const response = await fetch(SCRIPT_URL);
+                const data = await response.json();
+                if (data.success) {
+                    displaySlots(data.slots);
+                } else {
+                    throw new Error(data.error || 'Failed to load slots.');
+                }
+            } catch (error) {
+                console.error('Error fetching slots:', error);
+                timeSlotsContainer.innerHTML = `<p style="color: var(--danger);">Could not load available times. Please try again later.</p>`;
+            } finally {
+                slotsLoader.style.display = 'none';
+            }
+        }
+        function displaySlots(slots) {
+            if (slots.length === 0) {
+                timeSlotsContainer.innerHTML = `<p style="color: var(--light);">No available slots in the next 7 days. Please check back later.</p>`;
+                return;
+            }
+            const groupedSlots = slots.reduce((acc, slot) => {
+                const date = new Date(slot);
+                const day = date.toLocaleDateString(undefined, { weekday: 'long', month: 'long', day: 'numeric' });
+                if (!acc[day]) {
+                    acc[day] = [];
+                }
+                acc[day].push(slot);
+                return acc;
+            }, {});
+            let html = '';
+            for (const day in groupedSlots) {
+                html += `<div style="grid-column: 1 / -1;"><h4 style="color: var(--accent); margin-top: 1rem;">${day}</h4></div>`;
+                groupedSlots[day].forEach(slotISO => {
+                    const time = new Date(slotISO).toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit', hour12: false });
+                    html += `<div class="time-slot" data-value="${slotISO}">${time}</div>`;
+                });
+            }
+            timeSlotsContainer.innerHTML = html;
+        }
+        timeSlotsContainer.addEventListener('click', (e) => {
+            if (e.target.classList.contains('time-slot')) {
+                document.querySelectorAll('.time-slot').forEach(slot => slot.classList.remove('selected'));
+                e.target.classList.add('selected');
+                selectedSlot = e.target.dataset.value;
+            }
+        });
+        form.addEventListener('submit', async (e) => {
+            e.preventDefault();
+            if (!selectedSlot) {
+                alert('Please select a time slot.');
+                return;
+            }
+            submitBtn.disabled = true;
+            submitBtn.textContent = 'Scheduling...';
+            const formData = new FormData(form);
+            const data = {
+                name: formData.get('name'),
+                email: formData.get('email'),
+                details: formData.get('details'),
+                dateTime: selectedSlot,
+                lang: 'en'
+            };
+            try {
+                await fetch(SCRIPT_URL, {
+                    method: 'POST',
+                    mode: 'no-cors',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify(data)
+                });
+                form.style.display = 'none';
+                formMessage.style.display = 'block';
+                formMessage.className = 'success';
+                formMessage.innerHTML = "<h3>Thank You!</h3><p>Your meeting is scheduled. A confirmation email has been sent to you.</p>";
+            } catch (error) {
+                console.error('Error submitting form:', error);
+                formMessage.style.display = 'block';
+                formMessage.className = 'error';
+                formMessage.innerHTML = "<h3>Error</h3><p>Something went wrong. Please try again or contact me directly.</p>";
+                submitBtn.disabled = false;
+                submitBtn.textContent = 'Submit & Schedule';
+            }
+        });
+    </script>
 
     <script>
         // Wave Net Animation
@@ -1096,9 +1251,23 @@
         // Navigation toggle
         const navToggle = document.getElementById('navToggle');
         const navLinks = document.querySelector('.nav-links');
-        
+        const submenu = document.querySelector('.submenu');
+        const submenuLink = document.querySelector('.submenu > a');
+        const dropdown = document.querySelector('.submenu .dropdown');
+
         navToggle.addEventListener('click', () => {
             navLinks.classList.toggle('show');
+        });
+
+        submenuLink.addEventListener('click', (e) => {
+            e.preventDefault();
+            dropdown.classList.toggle('show');
+        });
+
+        document.addEventListener('click', (e) => {
+            if (!submenu.contains(e.target)) {
+                dropdown.classList.remove('show');
+            }
         });
         
         // Scroll effect for navigation

--- a/dist/payment.html
+++ b/dist/payment.html
@@ -18,12 +18,22 @@
     <link rel="icon" type="image/x-icon" href="/favicon.ico">
     <link rel="stylesheet" type="text/css" href="https://www.paypalobjects.com/webstatic/en_US/developer/docs/css/cardfields.css" />
     <style>
-        @import url('https://fonts.googleapis.com/css2?family=Marck+Script&display=swap');
         /* Your existing CSS - No changes made */
+        @import url('https://fonts.googleapis.com/css2?family=Marck+Script&display=swap');
         :root {
-            --primary: #4285F4; --secondary: #34A853; --accent: #FBBC04; --danger: #EA4335;
-            --dark: #202124; --light: #f8f9fa; --gray: #5f6368;
-            --gradient: linear-gradient(135deg, #4285F4 0%, #34A853 100%);
+            --primary: #00e676;
+            --primary-dark: #00c853;
+            --secondary: #448aff;
+            --dark: #0a0a0a;
+            --dark-secondary: #1a1a1a;
+            --dark-tertiary: #2a2a2a;
+            --light: #ffffff;
+            --text-primary: #e0e0e0;
+            --text-secondary: #9e9e9e;
+            --border-color: #333;
+            --accent: #fbbc04;
+            --danger: #ea4335;
+            --gray: #5f6368;
         }
         body {
             font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
@@ -40,34 +50,135 @@
         }
         @keyframes rotate { from { transform: rotate(0deg); } to { transform: rotate(360deg); } }
         nav {
-            position: fixed; top: 0; width: 100%; background: rgba(32, 33, 36, 0.9);
-            backdrop-filter: blur(10px); z-index: 1000; padding: 1rem 0; transition: all 0.3s ease;
-        }
-        nav.scrolled {
-            background: rgba(32, 33, 36, 0.98); box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);
+            position: fixed;
+            top: 0;
+            width: 100%;
+            background: rgba(10, 10, 10, 0.8);
+            backdrop-filter: blur(10px);
+            z-index: 1000;
+            padding: 1rem 0;
+            border-bottom: 1px solid rgba(51, 51, 51, 0.5);
         }
         .nav-container {
-            max-width: 1200px; margin: 0 auto; padding: 0 2rem; display: flex;
-            justify-content: space-between; align-items: center;
+            max-width: 1200px;
+            margin: 0 auto;
+            padding: 0 2rem;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
         }
         .logo {
-            font-family: 'Marck Script', cursive; font-size: 1.5rem; font-weight: 400; color: var(--light);
-            text-decoration: none; display: flex; align-items: center; gap: 0.8rem;
+            display: flex;
+            align-items: center;
+            gap: 0.75rem;
+            text-decoration: none;
+            color: var(--light);
+            font-size: 1.25rem;
+            font-weight: 600;
         }
-        .logo svg { width: 3rem; height: 3rem; }
-        .nav-links { display: flex; gap: 2rem; list-style: none; }
+        .logo svg {
+            width: 40px;
+            height: 40px;
+            border-radius: 8px;
+            background: var(--dark-secondary);
+            padding: 8px;
+            border: 1px solid var(--border-color);
+        }
+        .nav-toggle {
+            display: none;
+        }
+        .nav-links {
+            display: flex;
+            list-style: none;
+            gap: 2.5rem;
+            align-items: center;
+        }
+        .nav-links li {
+            position: relative;
+        }
         .nav-links a {
-            color: var(--light); text-decoration: none; transition: all 0.3s ease; position: relative;
+            color: var(--text-secondary);
+            text-decoration: none;
+            font-size: 0.9rem;
+            font-weight: 500;
+            transition: color 0.3s ease;
+            position: relative;
         }
-        .nav-links a::before {
-            content: ''; position: absolute; bottom: -5px; left: 0; width: 0; height: 2px;
-            background: var(--secondary); transition: width 0.3s ease;
+        .nav-links a:hover {
+            color: var(--light);
         }
-        .nav-links a:hover::before { width: 100%; }
+        .nav-links a::after {
+            content: '';
+            position: absolute;
+            bottom: -5px;
+            left: 0;
+            width: 0;
+            height: 2px;
+            background: var(--primary);
+            transition: width 0.3s ease;
+        }
+        .nav-links a:hover::after {
+            width: 100%;
+        }
+        .dropdown {
+            display: none;
+            flex-direction: column;
+            position: absolute;
+            top: calc(100% + 0.5rem);
+            left: 0;
+            background: var(--dark-secondary);
+            border: 1px solid var(--border-color);
+            padding: 0.5rem 0;
+            border-radius: 8px;
+            min-width: 200px;
+            z-index: 10;
+        }
+        .dropdown a {
+            padding: 0.5rem 1.5rem;
+            white-space: nowrap;
+        }
+        .dropdown a:hover {
+            background: var(--dark-tertiary);
+        }
+        .dropdown.show {
+            display: flex;
+        }
         .playground-link { position: relative; }
         .playground-link::after {
             content: '🎮'; position: absolute; right: -20px; top: 50%; transform: translateY(-50%);
             font-size: 0.8rem;
+        }
+        @media (max-width: 768px) {
+            .nav-links {
+                display: none;
+                position: absolute;
+                top: 100%;
+                right: 0;
+                background: var(--dark);
+                flex-direction: column;
+                padding: 1rem 2rem;
+                border: 1px solid var(--border-color);
+            }
+            .nav-links.show {
+                display: flex;
+            }
+            .nav-links .dropdown {
+                position: static;
+                background: transparent;
+                border: none;
+                padding: 0;
+            }
+            .dropdown a {
+                padding: 0.5rem 0;
+            }
+            .nav-toggle {
+                display: block;
+                background: none;
+                border: none;
+                color: var(--light);
+                font-size: 1.5rem;
+                cursor: pointer;
+            }
         }
         .payment-wrapper {
             min-height: 100vh; display: flex; align-items: center; justify-content: center;
@@ -152,7 +263,6 @@
             .payment-wrapper { padding: 5rem 1rem 1rem; }
         }
     </style>
-  <script type="module" crossorigin src="/assets/modulepreload-polyfill-B5Qt9EMX.js"></script>
 </head>
 <body>
     <!-- Google Tag Manager (noscript) -->
@@ -163,23 +273,24 @@
     
     <nav id="navbar">
         <div class="nav-container">
-            <a href="/index.html" class="logo">
-                <svg viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg">
-                    <path d="M40 48H8C5.79086 48 4 46.2091 4 44V4C4 1.79086 5.79086 0 8 0H30L44 14V44C44 46.2091 42.2091 48 40 48Z" fill="#2D2D30"/>
-                    <path d="M30 0L44 14H34C31.7909 14 30 12.2091 30 10V0Z" fill="#424242"/>
-                    <path d="M22 26L18 30L22 34" stroke="#4285F4" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-                    <path d="M30 26L34 30L30 34" stroke="#34A853" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-                    <path d="M20 40L24 36L28 40" stroke="#FBBC04" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-                </svg>
-                Automation by Meir
+            <a href="index.html" class="logo">
+                <svg viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M40 48H8C5.79086 48 4 46.2091 4 44V4C4 1.79086 5.79086 0 8 0H30L44 14V44C44 46.2091 42.2091 48 40 48Z" fill="#2D2D30"/><path d="M30 0L44 14H34C31.7909 14 30 12.2091 30 10V0Z" fill="#424242"/><path d="M22 26L18 30L22 34" stroke="#448aff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/><path d="M30 26L34 30L30 34" stroke="#00e676" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/><path d="M20 40L24 36L28 40" stroke="#fbbc04" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                Automations <span style="color: var(--text-secondary); font-weight: 400;">BY MEIR</span>
             </a>
+            <button class="nav-toggle" id="navToggle">☰</button>
             <ul class="nav-links">
-                <li><a href="/index.html#services">Services</a></li>
-                <li><a href="/index.html#projects">Projects</a></li>
-                <li><a href="/automation-playground.html" class="playground-link">Try It Live</a></li>
-                <li><a href="/index.html#about">About</a></li>
-                <li><a href="/why-automation.html">Why Automation?</a></li>
-                <li><a href="/index.html#contact">Contact</a></li>
+                <li><a href="index.html#services">Services</a></li>
+                <li><a href="index.html#projects">Projects</a></li>
+                <li><a href="automation-playground.html" class="playground-link">Try It Live</a></li>
+                <li class="submenu"><a href="#">Showcases</a>
+                    <ul class="dropdown">
+                        <li><a href="showcase1.html">Crypto Wallet Tracker</a></li>
+                        <li><a href="showcase2.html">Enterprise Analytics Dashboard</a></li>
+                    </ul>
+                </li>
+                <li><a href="why-automation.html">Why Automate</a></li>
+                <li><a href="index.html#contact">Contact</a></li>
+                <li><a href="index-he.html">עברית</a></li>
             </ul>
         </div>
     </nav>
@@ -211,6 +322,25 @@
 
     <script src="https://www.paypal.com/sdk/js?client-id=AaSn2JSC0jwjh-bbre2EiOkOIbd-L-H7RsN-LUYb1fiQqLZGdCfDlaTn0FQrj_Dc7F28Xo0eUcicOi22&buyer-country=US&currency=USD&components=buttons&enable-funding=venmo"></script>
     <script type="module" src="/app.js"></script>
+    <script>
+        const navToggle = document.getElementById('navToggle');
+        const navLinks = document.querySelector('.nav-links');
+        const submenu = document.querySelector('.submenu');
+        const submenuLink = document.querySelector('.submenu > a');
+        const dropdown = document.querySelector('.submenu .dropdown');
+        navToggle.addEventListener('click', () => {
+            navLinks.classList.toggle('show');
+        });
+        submenuLink.addEventListener('click', (e) => {
+            e.preventDefault();
+            dropdown.classList.toggle('show');
+        });
+        document.addEventListener('click', (e) => {
+            if (!submenu.contains(e.target)) {
+                dropdown.classList.remove('show');
+            }
+        });
+    </script>
 
 </body>
 </html>

--- a/dist/showcase1.html
+++ b/dist/showcase1.html
@@ -14,6 +14,22 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Crypto Wallet Tracker - Automated Portfolio Management System</title>
     <style>
+        :root {
+            --primary: #00e676;
+            --primary-dark: #00c853;
+            --secondary: #448aff;
+            --dark: #0a0a0a;
+            --dark-secondary: #1a1a1a;
+            --dark-tertiary: #2a2a2a;
+            --light: #ffffff;
+            --text-primary: #e0e0e0;
+            --text-secondary: #9e9e9e;
+            --border-color: #333;
+            --accent: #fbbc04;
+            --danger: #ea4335;
+            --gray: #5f6368;
+        }
+
         * {
             margin: 0;
             padding: 0;
@@ -21,9 +37,119 @@
         }
         body {
             font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-            background: #0a0a0a;
-            color: #ffffff;
+            background: var(--dark);
+            color: var(--light);
             overflow-x: hidden;
+        }
+        nav {
+            position: fixed;
+            top: 0;
+            width: 100%;
+            background: rgba(10, 10, 10, 0.8);
+            backdrop-filter: blur(10px);
+            z-index: 1000;
+            padding: 1rem 0;
+            border-bottom: 1px solid rgba(51, 51, 51, 0.5);
+        }
+        .nav-container {
+            max-width: 1200px;
+            margin: 0 auto;
+            padding: 0 2rem;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+        }
+        .logo {
+            display: flex;
+            align-items: center;
+            gap: 0.75rem;
+            text-decoration: none;
+            color: var(--light);
+            font-size: 1.25rem;
+            font-weight: 600;
+        }
+        .logo svg {
+            width: 40px;
+            height: 40px;
+            border-radius: 8px;
+            background: var(--dark-secondary);
+            padding: 8px;
+            border: 1px solid var(--border-color);
+        }
+        .nav-toggle { display: none; }
+        .nav-links {
+            display: flex;
+            list-style: none;
+            gap: 2.5rem;
+            align-items: center;
+        }
+        .nav-links li { position: relative; }
+        .nav-links a {
+            color: var(--text-secondary);
+            text-decoration: none;
+            font-size: 0.9rem;
+            font-weight: 500;
+            transition: color 0.3s ease;
+            position: relative;
+        }
+        .nav-links a:hover { color: var(--light); }
+        .nav-links a::after {
+            content: '';
+            position: absolute;
+            bottom: -5px;
+            left: 0;
+            width: 0;
+            height: 2px;
+            background: var(--primary);
+            transition: width 0.3s ease;
+        }
+        .nav-links a:hover::after { width: 100%; }
+        .dropdown {
+            display: none;
+            flex-direction: column;
+            position: absolute;
+            top: calc(100% + 0.5rem);
+            left: 0;
+            background: var(--dark-secondary);
+            border: 1px solid var(--border-color);
+            padding: 0.5rem 0;
+            border-radius: 8px;
+            min-width: 200px;
+            z-index: 10;
+        }
+        .dropdown a {
+            padding: 0.5rem 1.5rem;
+            white-space: nowrap;
+        }
+        .dropdown a:hover { background: var(--dark-tertiary); }
+        .dropdown.show { display: flex; }
+        @media (max-width: 768px) {
+            .nav-links {
+                display: none;
+                position: absolute;
+                top: 100%;
+                right: 0;
+                background: var(--dark);
+                flex-direction: column;
+                padding: 1rem 2rem;
+                border: 1px solid var(--border-color);
+            }
+            .nav-links.show { display: flex; }
+            .nav-links .dropdown {
+                position: static;
+                background: transparent;
+                border: none;
+                padding: 0;
+            }
+            .dropdown a { padding: 0.5rem 0; }
+            .nav-toggle {
+                display: block;
+                background: none;
+                border: none;
+                color: var(--light);
+                font-size: 1.5rem;
+                cursor: pointer;
+            }
         }
         /* Hero Section */
         .hero {
@@ -237,6 +363,29 @@
     <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-PZ9XZMFL"
     height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
     <!-- End Google Tag Manager (noscript) -->
+    <nav id="navbar">
+        <div class="nav-container">
+            <a href="index.html" class="logo">
+                <svg viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M40 48H8C5.79086 48 4 46.2091 4 44V4C4 1.79086 5.79086 0 8 0H30L44 14V44C44 46.2091 42.2091 48 40 48Z" fill="#2D2D30"/><path d="M30 0L44 14H34C31.7909 14 30 12.2091 30 10V0Z" fill="#424242"/><path d="M22 26L18 30L22 34" stroke="#448aff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/><path d="M30 26L34 30L30 34" stroke="#00e676" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/><path d="M20 40L24 36L28 40" stroke="#fbbc04" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                Automations <span style="color: var(--text-secondary); font-weight: 400;">BY MEIR</span>
+            </a>
+            <button class="nav-toggle" id="navToggle">☰</button>
+            <ul class="nav-links">
+                <li><a href="index.html#services">Services</a></li>
+                <li><a href="index.html#projects">Projects</a></li>
+                <li><a href="automation-playground.html" class="playground-link">Try It Live</a></li>
+                <li class="submenu"><a href="#">Showcases</a>
+                    <ul class="dropdown">
+                        <li><a href="showcase1.html">Crypto Wallet Tracker</a></li>
+                        <li><a href="showcase2.html">Enterprise Analytics Dashboard</a></li>
+                    </ul>
+                </li>
+                <li><a href="why-automation.html">Why Automate</a></li>
+                <li><a href="index.html#contact">Contact</a></li>
+                <li><a href="index-he.html">עברית</a></li>
+            </ul>
+        </div>
+    </nav>
     <section class="hero">
         <div class="hero-content">
             <h1>Crypto Wallet Tracker System</h1>
@@ -604,6 +753,25 @@
                     target.scrollIntoView({ behavior: 'smooth' });
                 }
             });
+        });
+    </script>
+    <script>
+        const navToggle = document.getElementById('navToggle');
+        const navLinks = document.querySelector('.nav-links');
+        const submenu = document.querySelector('.submenu');
+        const submenuLink = document.querySelector('.submenu > a');
+        const dropdown = document.querySelector('.submenu .dropdown');
+        navToggle.addEventListener('click', () => {
+            navLinks.classList.toggle('show');
+        });
+        submenuLink.addEventListener('click', (e) => {
+            e.preventDefault();
+            dropdown.classList.toggle('show');
+        });
+        document.addEventListener('click', (e) => {
+            if (!submenu.contains(e.target)) {
+                dropdown.classList.remove('show');
+            }
         });
     </script>
 </body>

--- a/dist/showcase2.html
+++ b/dist/showcase2.html
@@ -14,6 +14,22 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Enterprise Analytics Dashboard - Advanced Business Intelligence Solution</title>
     <style>
+        :root {
+            --primary: #00e676;
+            --primary-dark: #00c853;
+            --secondary: #448aff;
+            --dark: #0a0a0a;
+            --dark-secondary: #1a1a1a;
+            --dark-tertiary: #2a2a2a;
+            --light: #ffffff;
+            --text-primary: #e0e0e0;
+            --text-secondary: #9e9e9e;
+            --border-color: #333;
+            --accent: #fbbc04;
+            --danger: #ea4335;
+            --gray: #5f6368;
+        }
+
         * {
             margin: 0;
             padding: 0;
@@ -22,9 +38,117 @@
 
         body {
             font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-            background: #0a0a0a;
-            color: #ffffff;
+            background: var(--dark);
+            color: var(--light);
             overflow-x: hidden;
+        }
+
+        nav {
+            position: fixed;
+            top: 0;
+            width: 100%;
+            background: rgba(10, 10, 10, 0.8);
+            backdrop-filter: blur(10px);
+            z-index: 1000;
+            padding: 1rem 0;
+            border-bottom: 1px solid rgba(51, 51, 51, 0.5);
+        }
+        .nav-container {
+            max-width: 1200px;
+            margin: 0 auto;
+            padding: 0 2rem;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+        }
+        .logo {
+            display: flex;
+            align-items: center;
+            gap: 0.75rem;
+            text-decoration: none;
+            color: var(--light);
+            font-size: 1.25rem;
+            font-weight: 600;
+        }
+        .logo svg {
+            width: 40px;
+            height: 40px;
+            border-radius: 8px;
+            background: var(--dark-secondary);
+            padding: 8px;
+            border: 1px solid var(--border-color);
+        }
+        .nav-toggle { display: none; }
+        .nav-links {
+            display: flex;
+            list-style: none;
+            gap: 2.5rem;
+            align-items: center;
+        }
+        .nav-links li { position: relative; }
+        .nav-links a {
+            color: var(--text-secondary);
+            text-decoration: none;
+            font-size: 0.9rem;
+            font-weight: 500;
+            transition: color 0.3s ease;
+            position: relative;
+        }
+        .nav-links a:hover { color: var(--light); }
+        .nav-links a::after {
+            content: '';
+            position: absolute;
+            bottom: -5px;
+            left: 0;
+            width: 0;
+            height: 2px;
+            background: var(--primary);
+            transition: width 0.3s ease;
+        }
+        .nav-links a:hover::after { width: 100%; }
+        .dropdown {
+            display: none;
+            flex-direction: column;
+            position: absolute;
+            top: calc(100% + 0.5rem);
+            left: 0;
+            background: var(--dark-secondary);
+            border: 1px solid var(--border-color);
+            padding: 0.5rem 0;
+            border-radius: 8px;
+            min-width: 200px;
+            z-index: 10;
+        }
+        .dropdown a { padding: 0.5rem 1.5rem; white-space: nowrap; }
+        .dropdown a:hover { background: var(--dark-tertiary); }
+        .dropdown.show { display: flex; }
+        @media (max-width: 768px) {
+            .nav-links {
+                display: none;
+                position: absolute;
+                top: 100%;
+                right: 0;
+                background: var(--dark);
+                flex-direction: column;
+                padding: 1rem 2rem;
+                border: 1px solid var(--border-color);
+            }
+            .nav-links.show { display: flex; }
+            .nav-links .dropdown {
+                position: static;
+                background: transparent;
+                border: none;
+                padding: 0;
+            }
+            .dropdown a { padding: 0.5rem 0; }
+            .nav-toggle {
+                display: block;
+                background: none;
+                border: none;
+                color: var(--light);
+                font-size: 1.5rem;
+                cursor: pointer;
+            }
         }
 
         /* Hero Section */
@@ -362,6 +486,29 @@
     <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-PZ9XZMFL"
     height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
     <!-- End Google Tag Manager (noscript) -->
+    <nav id="navbar">
+        <div class="nav-container">
+            <a href="index.html" class="logo">
+                <svg viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M40 48H8C5.79086 48 4 46.2091 4 44V4C4 1.79086 5.79086 0 8 0H30L44 14V44C44 46.2091 42.2091 48 40 48Z" fill="#2D2D30"/><path d="M30 0L44 14H34C31.7909 14 30 12.2091 30 10V0Z" fill="#424242"/><path d="M22 26L18 30L22 34" stroke="#448aff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/><path d="M30 26L34 30L30 34" stroke="#00e676" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/><path d="M20 40L24 36L28 40" stroke="#fbbc04" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                Automations <span style="color: var(--text-secondary); font-weight: 400;">BY MEIR</span>
+            </a>
+            <button class="nav-toggle" id="navToggle">☰</button>
+            <ul class="nav-links">
+                <li><a href="index.html#services">Services</a></li>
+                <li><a href="index.html#projects">Projects</a></li>
+                <li><a href="automation-playground.html" class="playground-link">Try It Live</a></li>
+                <li class="submenu"><a href="#">Showcases</a>
+                    <ul class="dropdown">
+                        <li><a href="showcase1.html">Crypto Wallet Tracker</a></li>
+                        <li><a href="showcase2.html">Enterprise Analytics Dashboard</a></li>
+                    </ul>
+                </li>
+                <li><a href="why-automation.html">Why Automate</a></li>
+                <li><a href="index.html#contact">Contact</a></li>
+                <li><a href="index-he.html">עברית</a></li>
+            </ul>
+        </div>
+    </nav>
     <!-- Hero Section -->
     <section class="hero">
         <div class="hero-content">
@@ -751,6 +898,25 @@
                 mockup.addEventListener('mouseleave', () => {
                     mockup.style.transform = 'rotateX(5deg)';
                 });
+            }
+        });
+    </script>
+    <script>
+        const navToggle = document.getElementById('navToggle');
+        const navLinks = document.querySelector('.nav-links');
+        const submenu = document.querySelector('.submenu');
+        const submenuLink = document.querySelector('.submenu > a');
+        const dropdown = document.querySelector('.submenu .dropdown');
+        navToggle.addEventListener('click', () => {
+            navLinks.classList.toggle('show');
+        });
+        submenuLink.addEventListener('click', (e) => {
+            e.preventDefault();
+            dropdown.classList.toggle('show');
+        });
+        document.addEventListener('click', (e) => {
+            if (!submenu.contains(e.target)) {
+                dropdown.classList.remove('show');
             }
         });
     </script>

--- a/dist/why-automation.html
+++ b/dist/why-automation.html
@@ -9,26 +9,105 @@
     <style>
         @import url('https://fonts.googleapis.com/css2?family=Marck+Script&display=swap');
         :root {
-            --primary: #4285F4; --secondary: #34A853; --accent: #FBBC04; --danger: #EA4335;
-            --dark: #202124; --light: #f8f9fa; --gray: #5f6368;
-            --gradient: linear-gradient(135deg, #4285F4 0%, #34A853 100%);
+            --primary: #00e676;
+            --primary-dark: #00c853;
+            --secondary: #448aff;
+            --dark: #0a0a0a;
+            --dark-secondary: #1a1a1a;
+            --dark-tertiary: #2a2a2a;
+            --light: #ffffff;
+            --text-primary: #e0e0e0;
+            --text-secondary: #9e9e9e;
+            --border-color: #333;
+            --accent: #fbbc04;
+            --danger: #ea4335;
+            --gray: #5f6368;
         }
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; background:#000; color:var(--light); margin:0; }
-        nav { position: fixed; top:0; width:100%; background:rgba(32,33,36,0.9); backdrop-filter:blur(10px); z-index:1000; padding:1rem 0; }
-        .nav-container { max-width:1200px; margin:0 auto; padding:0 2rem; display:flex; justify-content:space-between; align-items:center; }
-        .logo { font-family:'Marck Script',cursive; font-size:1.5rem; color:var(--light); text-decoration:none; display:flex; align-items:center; gap:.8rem; }
-        .logo svg { width:3rem; height:3rem; }
-        .nav-toggle { display:none; }
-        .nav-links { display:flex; gap:2rem; list-style:none; }
-        .nav-links li { position:relative; }
-        .nav-links a { color:var(--light); text-decoration:none; position:relative; }
-        .dropdown { display:none; flex-direction:column; position:absolute; top:calc(100% + 0.5rem); left:0; background:rgba(32,33,36,0.9); padding:.5rem 0; border-radius:8px; min-width:250px; }
-        .dropdown.show{display:flex;}
-        .dropdown a{padding:.5rem 1rem; display:block;}
+        nav {
+            position: fixed;
+            top: 0;
+            width: 100%;
+            background: rgba(10, 10, 10, 0.8);
+            backdrop-filter: blur(10px);
+            z-index: 1000;
+            padding: 1rem 0;
+            border-bottom: 1px solid rgba(51, 51, 51, 0.5);
+        }
+        .nav-container {
+            max-width: 1200px;
+            margin: 0 auto;
+            padding: 0 2rem;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+        }
+        .logo {
+            display: flex;
+            align-items: center;
+            gap: 0.75rem;
+            text-decoration: none;
+            color: var(--light);
+            font-size: 1.25rem;
+            font-weight: 600;
+        }
+        .logo svg {
+            width: 40px;
+            height: 40px;
+            border-radius: 8px;
+            background: var(--dark-secondary);
+            padding: 8px;
+            border: 1px solid var(--border-color);
+        }
+        .nav-toggle { display: none; }
+        .nav-links {
+            display: flex;
+            list-style: none;
+            gap: 2.5rem;
+            align-items: center;
+        }
+        .nav-links li { position: relative; }
+        .nav-links a {
+            color: var(--text-secondary);
+            text-decoration: none;
+            font-size: 0.9rem;
+            font-weight: 500;
+            transition: color 0.3s ease;
+            position: relative;
+        }
+        .nav-links a:hover { color: var(--light); }
+        .nav-links a::after {
+            content: '';
+            position: absolute;
+            bottom: -5px;
+            left: 0;
+            width: 0;
+            height: 2px;
+            background: var(--primary);
+            transition: width 0.3s ease;
+        }
+        .nav-links a:hover::after { width: 100%; }
+        .dropdown {
+            display: none;
+            flex-direction: column;
+            position: absolute;
+            top: calc(100% + 0.5rem);
+            left: 0;
+            background: var(--dark-secondary);
+            border: 1px solid var(--border-color);
+            padding: 0.5rem 0;
+            border-radius: 8px;
+            min-width: 200px;
+            z-index: 10;
+        }
+        .dropdown a { padding: 0.5rem 1.5rem; white-space: nowrap; }
+        .dropdown a:hover { background: var(--dark-tertiary); }
+        .dropdown.show { display: flex; }
         @media (max-width:768px){
-            .nav-links{ display:none; position:absolute; top:100%; right:0; background:rgba(32,33,36,0.95); flex-direction:column; gap:1rem; padding:1rem 2rem; }
+            .nav-links{ display:none; position:absolute; top:100%; right:0; background:var(--dark); flex-direction:column; gap:1rem; padding:1rem 2rem; border:1px solid var(--border-color); }
             .nav-links.show{display:flex;}
-            .nav-links .dropdown{position:static; background:transparent; padding:0 0 0 1rem;}
+            .nav-links .dropdown{position:static; background:transparent; border:none; padding:0;}
+            .dropdown a{ padding:0.5rem 0; }
             .nav-toggle{ display:block; background:none; border:none; color:var(--light); font-size:1.5rem; cursor:pointer; }
         }
         article{max-width:800px; margin:6rem auto 2rem; padding:0 1rem; line-height:1.8;}
@@ -40,10 +119,10 @@
     <nav id="navbar">
         <div class="nav-container">
             <a href="index.html" class="logo">
-                <svg viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M40 48H8C5.79086 48 4 46.2091 4 44V4C4 1.79086 5.79086 0 8 0H30L44 14V44C44 46.2091 42.2091 48 40 48Z" fill="#2D2D30"/><path d="M30 0L44 14H34C31.7909 14 30 12.2091 30 10V0Z" fill="#424242"/><path d="M22 26L18 30L22 34" stroke="#4285F4" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/><path d="M30 26L34 30L30 34" stroke="#34A853" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/><path d="M20 40L24 36L28 40" stroke="#FBBC04" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
-                Automation by Meir
+                <svg viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M40 48H8C5.79086 48 4 46.2091 4 44V4C4 1.79086 5.79086 0 8 0H30L44 14V44C44 46.2091 42.2091 48 40 48Z" fill="#2D2D30"/><path d="M30 0L44 14H34C31.7909 14 30 12.2091 30 10V0Z" fill="#424242"/><path d="M22 26L18 30L22 34" stroke="#448aff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/><path d="M30 26L34 30L30 34" stroke="#00e676" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/><path d="M20 40L24 36L28 40" stroke="#fbbc04" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                Automations <span style="color: var(--text-secondary); font-weight: 400;">BY MEIR</span>
             </a>
-            <button class="nav-toggle" id="navToggle">&#9776;</button>
+            <button class="nav-toggle" id="navToggle">☰</button>
             <ul class="nav-links">
                 <li><a href="index.html#services">Services</a></li>
                 <li><a href="index.html#projects">Projects</a></li>
@@ -56,8 +135,9 @@
                 </li>
                 <li><a href="index.html#about">About</a></li>
                 <li><a href="payment.html">Payments</a></li>
-                <li><a href="why-automation.html">Why Automation?</a></li>
+                <li><a href="why-automation.html">Why Automate</a></li>
                 <li><a href="index.html#contact">Contact</a></li>
+                <li><a href="index-he.html">עברית</a></li>
             </ul>
         </div>
     </nav>

--- a/public/automation-playground.html
+++ b/public/automation-playground.html
@@ -15,6 +15,22 @@
     <title>Automation Puzzle - Build Your Perfect Workflow</title>
     <style>
         @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap');
+
+        :root {
+            --primary: #00e676;
+            --primary-dark: #00c853;
+            --secondary: #448aff;
+            --dark: #0a0a0a;
+            --dark-secondary: #1a1a1a;
+            --dark-tertiary: #2a2a2a;
+            --light: #ffffff;
+            --text-primary: #e0e0e0;
+            --text-secondary: #9e9e9e;
+            --border-color: #333;
+            --accent: #fbbc04;
+            --danger: #ea4335;
+            --gray: #5f6368;
+        }
         
         * {
             margin: 0;
@@ -28,6 +44,152 @@
             color: #f8f9fa;
             overflow: hidden;
             position: relative;
+        }
+
+        nav {
+            position: fixed;
+            top: 0;
+            width: 100%;
+            background: rgba(10, 10, 10, 0.8);
+            backdrop-filter: blur(10px);
+            z-index: 1000;
+            padding: 1rem 0;
+            border-bottom: 1px solid rgba(51, 51, 51, 0.5);
+        }
+
+        .nav-container {
+            max-width: 1200px;
+            margin: 0 auto;
+            padding: 0 2rem;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+        }
+
+        .logo {
+            display: flex;
+            align-items: center;
+            gap: 0.75rem;
+            text-decoration: none;
+            color: var(--light);
+            font-size: 1.25rem;
+            font-weight: 600;
+        }
+
+        .logo svg {
+            width: 40px;
+            height: 40px;
+            border-radius: 8px;
+            background: var(--dark-secondary);
+            padding: 8px;
+            border: 1px solid var(--border-color);
+        }
+
+        .nav-toggle {
+            display: none;
+        }
+
+        .nav-links {
+            display: flex;
+            list-style: none;
+            gap: 2.5rem;
+            align-items: center;
+        }
+
+        .nav-links li {
+            position: relative;
+        }
+
+        .nav-links a {
+            color: var(--text-secondary);
+            text-decoration: none;
+            font-size: 0.9rem;
+            font-weight: 500;
+            transition: color 0.3s ease;
+            position: relative;
+        }
+
+        .nav-links a:hover {
+            color: var(--light);
+        }
+
+        .nav-links a::after {
+            content: '';
+            position: absolute;
+            bottom: -5px;
+            left: 0;
+            width: 0;
+            height: 2px;
+            background: var(--primary);
+            transition: width 0.3s ease;
+        }
+
+        .nav-links a:hover::after {
+            width: 100%;
+        }
+
+        .dropdown {
+            display: none;
+            flex-direction: column;
+            position: absolute;
+            top: calc(100% + 0.5rem);
+            left: 0;
+            background: var(--dark-secondary);
+            border: 1px solid var(--border-color);
+            padding: 0.5rem 0;
+            border-radius: 8px;
+            min-width: 200px;
+            z-index: 10;
+        }
+
+        .dropdown a {
+            padding: 0.5rem 1.5rem;
+            white-space: nowrap;
+        }
+
+        .dropdown a:hover {
+            background: var(--dark-tertiary);
+        }
+
+        .dropdown.show {
+            display: flex;
+        }
+
+        @media (max-width: 768px) {
+            .nav-links {
+                display: none;
+                position: absolute;
+                top: 100%;
+                right: 0;
+                background: var(--dark);
+                flex-direction: column;
+                padding: 1rem 2rem;
+                border: 1px solid var(--border-color);
+            }
+
+            .nav-links.show {
+                display: flex;
+            }
+
+            .nav-links .dropdown {
+                position: static;
+                background: transparent;
+                border: none;
+                padding: 0;
+            }
+
+            .dropdown a {
+                padding: 0.5rem 0;
+            }
+
+            .nav-toggle {
+                display: block;
+                background: none;
+                border: none;
+                color: var(--light);
+                font-size: 1.5rem;
+                cursor: pointer;
+            }
         }
 
         /* Background Animation */
@@ -459,6 +621,29 @@
     <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-PZ9XZMFL"
     height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
     <!-- End Google Tag Manager (noscript) -->
+    <nav id="navbar">
+        <div class="nav-container">
+            <a href="index.html" class="logo">
+                <svg viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M40 48H8C5.79086 48 4 46.2091 4 44V4C4 1.79086 5.79086 0 8 0H30L44 14V44C44 46.2091 42.2091 48 40 48Z" fill="#2D2D30"/><path d="M30 0L44 14H34C31.7909 14 30 12.2091 30 10V0Z" fill="#424242"/><path d="M22 26L18 30L22 34" stroke="#448aff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/><path d="M30 26L34 30L30 34" stroke="#00e676" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/><path d="M20 40L24 36L28 40" stroke="#fbbc04" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                Automations <span style="color: var(--text-secondary); font-weight: 400;">BY MEIR</span>
+            </a>
+            <button class="nav-toggle" id="navToggle">☰</button>
+            <ul class="nav-links">
+                <li><a href="index.html#services">Services</a></li>
+                <li><a href="index.html#projects">Projects</a></li>
+                <li><a href="automation-playground.html" class="playground-link">Try It Live</a></li>
+                <li class="submenu"><a href="#">Showcases</a>
+                    <ul class="dropdown">
+                        <li><a href="showcase1.html">Crypto Wallet Tracker</a></li>
+                        <li><a href="showcase2.html">Enterprise Analytics Dashboard</a></li>
+                    </ul>
+                </li>
+                <li><a href="why-automation.html">Why Automate</a></li>
+                <li><a href="index.html#contact">Contact</a></li>
+                <li><a href="index-he.html">עברית</a></li>
+            </ul>
+        </div>
+    </nav>
     <div class="bg-grid"></div>
     
     <!-- Floating Particles -->
@@ -1296,6 +1481,25 @@
 
         // Initialize on load
         createParticles();
+    </script>
+    <script>
+        const navToggle = document.getElementById('navToggle');
+        const navLinks = document.querySelector('.nav-links');
+        const submenu = document.querySelector('.submenu');
+        const submenuLink = document.querySelector('.submenu > a');
+        const dropdown = document.querySelector('.submenu .dropdown');
+        navToggle.addEventListener('click', () => {
+            navLinks.classList.toggle('show');
+        });
+        submenuLink.addEventListener('click', (e) => {
+            e.preventDefault();
+            dropdown.classList.toggle('show');
+        });
+        document.addEventListener('click', (e) => {
+            if (!submenu.contains(e.target)) {
+                dropdown.classList.remove('show');
+            }
+        });
     </script>
 </body>
 </html>

--- a/public/index.html
+++ b/public/index.html
@@ -97,6 +97,10 @@
             gap: 2.5rem;
             align-items: center;
         }
+
+        .nav-links li {
+            position: relative;
+        }
         
         .nav-links a {
             color: var(--text-secondary);
@@ -124,6 +128,33 @@
         
         .nav-links a:hover::after {
             width: 100%;
+        }
+
+        .dropdown {
+            display: none;
+            flex-direction: column;
+            position: absolute;
+            top: calc(100% + 0.5rem);
+            left: 0;
+            background: var(--dark-secondary);
+            border: 1px solid var(--border-color);
+            padding: 0.5rem 0;
+            border-radius: 8px;
+            min-width: 200px;
+            z-index: 10;
+        }
+
+        .dropdown a {
+            padding: 0.5rem 1.5rem;
+            white-space: nowrap;
+        }
+
+        .dropdown a:hover {
+            background: var(--dark-tertiary);
+        }
+
+        .dropdown.show {
+            display: flex;
         }
         
         /* Hero Section */
@@ -604,9 +635,20 @@
                 padding: 1rem 2rem;
                 border: 1px solid var(--border-color);
             }
-            
+
             .nav-links.show {
                 display: flex;
+            }
+
+            .nav-links .dropdown {
+                position: static;
+                background: transparent;
+                border: none;
+                padding: 0;
+            }
+
+            .dropdown a {
+                padding: 0.5rem 0;
             }
             
             .nav-toggle {
@@ -709,9 +751,15 @@
                 <li><a href="#services">Services</a></li>
                 <li><a href="#projects">Projects</a></li>
                 <li><a href="automation-playground.html" class="playground-link">Try It Live</a></li>
-                <li><a href="#about">Showcases</a></li>
-                <li><a href="#why">Why Automate</a></li>
+                <li class="submenu"><a href="#">Showcases</a>
+                    <ul class="dropdown">
+                        <li><a href="showcase1.html">Crypto Wallet Tracker</a></li>
+                        <li><a href="showcase2.html">Enterprise Analytics Dashboard</a></li>
+                    </ul>
+                </li>
+                <li><a href="why-automation.html">Why Automate</a></li>
                 <li><a href="#contact">Contact</a></li>
+                <li><a href="index-he.html">עברית</a></li>
             </ul>
         </div>
     </nav>
@@ -1203,9 +1251,23 @@
         // Navigation toggle
         const navToggle = document.getElementById('navToggle');
         const navLinks = document.querySelector('.nav-links');
-        
+        const submenu = document.querySelector('.submenu');
+        const submenuLink = document.querySelector('.submenu > a');
+        const dropdown = document.querySelector('.submenu .dropdown');
+
         navToggle.addEventListener('click', () => {
             navLinks.classList.toggle('show');
+        });
+
+        submenuLink.addEventListener('click', (e) => {
+            e.preventDefault();
+            dropdown.classList.toggle('show');
+        });
+
+        document.addEventListener('click', (e) => {
+            if (!submenu.contains(e.target)) {
+                dropdown.classList.remove('show');
+            }
         });
         
         // Scroll effect for navigation

--- a/public/payment.html
+++ b/public/payment.html
@@ -21,9 +21,19 @@
         /* Your existing CSS - No changes made */
         @import url('https://fonts.googleapis.com/css2?family=Marck+Script&display=swap');
         :root {
-            --primary: #4285F4; --secondary: #34A853; --accent: #FBBC04; --danger: #EA4335;
-            --dark: #202124; --light: #f8f9fa; --gray: #5f6368;
-            --gradient: linear-gradient(135deg, #4285F4 0%, #34A853 100%);
+            --primary: #00e676;
+            --primary-dark: #00c853;
+            --secondary: #448aff;
+            --dark: #0a0a0a;
+            --dark-secondary: #1a1a1a;
+            --dark-tertiary: #2a2a2a;
+            --light: #ffffff;
+            --text-primary: #e0e0e0;
+            --text-secondary: #9e9e9e;
+            --border-color: #333;
+            --accent: #fbbc04;
+            --danger: #ea4335;
+            --gray: #5f6368;
         }
         body {
             font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
@@ -40,34 +50,135 @@
         }
         @keyframes rotate { from { transform: rotate(0deg); } to { transform: rotate(360deg); } }
         nav {
-            position: fixed; top: 0; width: 100%; background: rgba(32, 33, 36, 0.9);
-            backdrop-filter: blur(10px); z-index: 1000; padding: 1rem 0; transition: all 0.3s ease;
-        }
-        nav.scrolled {
-            background: rgba(32, 33, 36, 0.98); box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);
+            position: fixed;
+            top: 0;
+            width: 100%;
+            background: rgba(10, 10, 10, 0.8);
+            backdrop-filter: blur(10px);
+            z-index: 1000;
+            padding: 1rem 0;
+            border-bottom: 1px solid rgba(51, 51, 51, 0.5);
         }
         .nav-container {
-            max-width: 1200px; margin: 0 auto; padding: 0 2rem; display: flex;
-            justify-content: space-between; align-items: center;
+            max-width: 1200px;
+            margin: 0 auto;
+            padding: 0 2rem;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
         }
         .logo {
-            font-family: 'Marck Script', cursive; font-size: 1.5rem; font-weight: 400; color: var(--light);
-            text-decoration: none; display: flex; align-items: center; gap: 0.8rem;
+            display: flex;
+            align-items: center;
+            gap: 0.75rem;
+            text-decoration: none;
+            color: var(--light);
+            font-size: 1.25rem;
+            font-weight: 600;
         }
-        .logo svg { width: 3rem; height: 3rem; }
-        .nav-links { display: flex; gap: 2rem; list-style: none; }
+        .logo svg {
+            width: 40px;
+            height: 40px;
+            border-radius: 8px;
+            background: var(--dark-secondary);
+            padding: 8px;
+            border: 1px solid var(--border-color);
+        }
+        .nav-toggle {
+            display: none;
+        }
+        .nav-links {
+            display: flex;
+            list-style: none;
+            gap: 2.5rem;
+            align-items: center;
+        }
+        .nav-links li {
+            position: relative;
+        }
         .nav-links a {
-            color: var(--light); text-decoration: none; transition: all 0.3s ease; position: relative;
+            color: var(--text-secondary);
+            text-decoration: none;
+            font-size: 0.9rem;
+            font-weight: 500;
+            transition: color 0.3s ease;
+            position: relative;
         }
-        .nav-links a::before {
-            content: ''; position: absolute; bottom: -5px; left: 0; width: 0; height: 2px;
-            background: var(--secondary); transition: width 0.3s ease;
+        .nav-links a:hover {
+            color: var(--light);
         }
-        .nav-links a:hover::before { width: 100%; }
+        .nav-links a::after {
+            content: '';
+            position: absolute;
+            bottom: -5px;
+            left: 0;
+            width: 0;
+            height: 2px;
+            background: var(--primary);
+            transition: width 0.3s ease;
+        }
+        .nav-links a:hover::after {
+            width: 100%;
+        }
+        .dropdown {
+            display: none;
+            flex-direction: column;
+            position: absolute;
+            top: calc(100% + 0.5rem);
+            left: 0;
+            background: var(--dark-secondary);
+            border: 1px solid var(--border-color);
+            padding: 0.5rem 0;
+            border-radius: 8px;
+            min-width: 200px;
+            z-index: 10;
+        }
+        .dropdown a {
+            padding: 0.5rem 1.5rem;
+            white-space: nowrap;
+        }
+        .dropdown a:hover {
+            background: var(--dark-tertiary);
+        }
+        .dropdown.show {
+            display: flex;
+        }
         .playground-link { position: relative; }
         .playground-link::after {
             content: '🎮'; position: absolute; right: -20px; top: 50%; transform: translateY(-50%);
             font-size: 0.8rem;
+        }
+        @media (max-width: 768px) {
+            .nav-links {
+                display: none;
+                position: absolute;
+                top: 100%;
+                right: 0;
+                background: var(--dark);
+                flex-direction: column;
+                padding: 1rem 2rem;
+                border: 1px solid var(--border-color);
+            }
+            .nav-links.show {
+                display: flex;
+            }
+            .nav-links .dropdown {
+                position: static;
+                background: transparent;
+                border: none;
+                padding: 0;
+            }
+            .dropdown a {
+                padding: 0.5rem 0;
+            }
+            .nav-toggle {
+                display: block;
+                background: none;
+                border: none;
+                color: var(--light);
+                font-size: 1.5rem;
+                cursor: pointer;
+            }
         }
         .payment-wrapper {
             min-height: 100vh; display: flex; align-items: center; justify-content: center;
@@ -162,23 +273,24 @@
     
     <nav id="navbar">
         <div class="nav-container">
-            <a href="/index.html" class="logo">
-                <svg viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg">
-                    <path d="M40 48H8C5.79086 48 4 46.2091 4 44V4C4 1.79086 5.79086 0 8 0H30L44 14V44C44 46.2091 42.2091 48 40 48Z" fill="#2D2D30"/>
-                    <path d="M30 0L44 14H34C31.7909 14 30 12.2091 30 10V0Z" fill="#424242"/>
-                    <path d="M22 26L18 30L22 34" stroke="#4285F4" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-                    <path d="M30 26L34 30L30 34" stroke="#34A853" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-                    <path d="M20 40L24 36L28 40" stroke="#FBBC04" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-                </svg>
-                Automation by Meir
+            <a href="index.html" class="logo">
+                <svg viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M40 48H8C5.79086 48 4 46.2091 4 44V4C4 1.79086 5.79086 0 8 0H30L44 14V44C44 46.2091 42.2091 48 40 48Z" fill="#2D2D30"/><path d="M30 0L44 14H34C31.7909 14 30 12.2091 30 10V0Z" fill="#424242"/><path d="M22 26L18 30L22 34" stroke="#448aff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/><path d="M30 26L34 30L30 34" stroke="#00e676" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/><path d="M20 40L24 36L28 40" stroke="#fbbc04" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                Automations <span style="color: var(--text-secondary); font-weight: 400;">BY MEIR</span>
             </a>
+            <button class="nav-toggle" id="navToggle">☰</button>
             <ul class="nav-links">
-                <li><a href="/index.html#services">Services</a></li>
-                <li><a href="/index.html#projects">Projects</a></li>
-                <li><a href="/automation-playground.html" class="playground-link">Try It Live</a></li>
-                <li><a href="/index.html#about">About</a></li>
-                <li><a href="/why-automation.html">Why Automation?</a></li>
-                <li><a href="/index.html#contact">Contact</a></li>
+                <li><a href="index.html#services">Services</a></li>
+                <li><a href="index.html#projects">Projects</a></li>
+                <li><a href="automation-playground.html" class="playground-link">Try It Live</a></li>
+                <li class="submenu"><a href="#">Showcases</a>
+                    <ul class="dropdown">
+                        <li><a href="showcase1.html">Crypto Wallet Tracker</a></li>
+                        <li><a href="showcase2.html">Enterprise Analytics Dashboard</a></li>
+                    </ul>
+                </li>
+                <li><a href="why-automation.html">Why Automate</a></li>
+                <li><a href="index.html#contact">Contact</a></li>
+                <li><a href="index-he.html">עברית</a></li>
             </ul>
         </div>
     </nav>
@@ -210,6 +322,25 @@
 
     <script src="https://www.paypal.com/sdk/js?client-id=AaSn2JSC0jwjh-bbre2EiOkOIbd-L-H7RsN-LUYb1fiQqLZGdCfDlaTn0FQrj_Dc7F28Xo0eUcicOi22&buyer-country=US&currency=USD&components=buttons&enable-funding=venmo"></script>
     <script type="module" src="/app.js"></script>
+    <script>
+        const navToggle = document.getElementById('navToggle');
+        const navLinks = document.querySelector('.nav-links');
+        const submenu = document.querySelector('.submenu');
+        const submenuLink = document.querySelector('.submenu > a');
+        const dropdown = document.querySelector('.submenu .dropdown');
+        navToggle.addEventListener('click', () => {
+            navLinks.classList.toggle('show');
+        });
+        submenuLink.addEventListener('click', (e) => {
+            e.preventDefault();
+            dropdown.classList.toggle('show');
+        });
+        document.addEventListener('click', (e) => {
+            if (!submenu.contains(e.target)) {
+                dropdown.classList.remove('show');
+            }
+        });
+    </script>
 
 </body>
 </html>

--- a/public/showcase1.html
+++ b/public/showcase1.html
@@ -14,6 +14,22 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Crypto Wallet Tracker - Automated Portfolio Management System</title>
     <style>
+        :root {
+            --primary: #00e676;
+            --primary-dark: #00c853;
+            --secondary: #448aff;
+            --dark: #0a0a0a;
+            --dark-secondary: #1a1a1a;
+            --dark-tertiary: #2a2a2a;
+            --light: #ffffff;
+            --text-primary: #e0e0e0;
+            --text-secondary: #9e9e9e;
+            --border-color: #333;
+            --accent: #fbbc04;
+            --danger: #ea4335;
+            --gray: #5f6368;
+        }
+
         * {
             margin: 0;
             padding: 0;
@@ -21,9 +37,119 @@
         }
         body {
             font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-            background: #0a0a0a;
-            color: #ffffff;
+            background: var(--dark);
+            color: var(--light);
             overflow-x: hidden;
+        }
+        nav {
+            position: fixed;
+            top: 0;
+            width: 100%;
+            background: rgba(10, 10, 10, 0.8);
+            backdrop-filter: blur(10px);
+            z-index: 1000;
+            padding: 1rem 0;
+            border-bottom: 1px solid rgba(51, 51, 51, 0.5);
+        }
+        .nav-container {
+            max-width: 1200px;
+            margin: 0 auto;
+            padding: 0 2rem;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+        }
+        .logo {
+            display: flex;
+            align-items: center;
+            gap: 0.75rem;
+            text-decoration: none;
+            color: var(--light);
+            font-size: 1.25rem;
+            font-weight: 600;
+        }
+        .logo svg {
+            width: 40px;
+            height: 40px;
+            border-radius: 8px;
+            background: var(--dark-secondary);
+            padding: 8px;
+            border: 1px solid var(--border-color);
+        }
+        .nav-toggle { display: none; }
+        .nav-links {
+            display: flex;
+            list-style: none;
+            gap: 2.5rem;
+            align-items: center;
+        }
+        .nav-links li { position: relative; }
+        .nav-links a {
+            color: var(--text-secondary);
+            text-decoration: none;
+            font-size: 0.9rem;
+            font-weight: 500;
+            transition: color 0.3s ease;
+            position: relative;
+        }
+        .nav-links a:hover { color: var(--light); }
+        .nav-links a::after {
+            content: '';
+            position: absolute;
+            bottom: -5px;
+            left: 0;
+            width: 0;
+            height: 2px;
+            background: var(--primary);
+            transition: width 0.3s ease;
+        }
+        .nav-links a:hover::after { width: 100%; }
+        .dropdown {
+            display: none;
+            flex-direction: column;
+            position: absolute;
+            top: calc(100% + 0.5rem);
+            left: 0;
+            background: var(--dark-secondary);
+            border: 1px solid var(--border-color);
+            padding: 0.5rem 0;
+            border-radius: 8px;
+            min-width: 200px;
+            z-index: 10;
+        }
+        .dropdown a {
+            padding: 0.5rem 1.5rem;
+            white-space: nowrap;
+        }
+        .dropdown a:hover { background: var(--dark-tertiary); }
+        .dropdown.show { display: flex; }
+        @media (max-width: 768px) {
+            .nav-links {
+                display: none;
+                position: absolute;
+                top: 100%;
+                right: 0;
+                background: var(--dark);
+                flex-direction: column;
+                padding: 1rem 2rem;
+                border: 1px solid var(--border-color);
+            }
+            .nav-links.show { display: flex; }
+            .nav-links .dropdown {
+                position: static;
+                background: transparent;
+                border: none;
+                padding: 0;
+            }
+            .dropdown a { padding: 0.5rem 0; }
+            .nav-toggle {
+                display: block;
+                background: none;
+                border: none;
+                color: var(--light);
+                font-size: 1.5rem;
+                cursor: pointer;
+            }
         }
         /* Hero Section */
         .hero {
@@ -237,6 +363,29 @@
     <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-PZ9XZMFL"
     height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
     <!-- End Google Tag Manager (noscript) -->
+    <nav id="navbar">
+        <div class="nav-container">
+            <a href="index.html" class="logo">
+                <svg viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M40 48H8C5.79086 48 4 46.2091 4 44V4C4 1.79086 5.79086 0 8 0H30L44 14V44C44 46.2091 42.2091 48 40 48Z" fill="#2D2D30"/><path d="M30 0L44 14H34C31.7909 14 30 12.2091 30 10V0Z" fill="#424242"/><path d="M22 26L18 30L22 34" stroke="#448aff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/><path d="M30 26L34 30L30 34" stroke="#00e676" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/><path d="M20 40L24 36L28 40" stroke="#fbbc04" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                Automations <span style="color: var(--text-secondary); font-weight: 400;">BY MEIR</span>
+            </a>
+            <button class="nav-toggle" id="navToggle">☰</button>
+            <ul class="nav-links">
+                <li><a href="index.html#services">Services</a></li>
+                <li><a href="index.html#projects">Projects</a></li>
+                <li><a href="automation-playground.html" class="playground-link">Try It Live</a></li>
+                <li class="submenu"><a href="#">Showcases</a>
+                    <ul class="dropdown">
+                        <li><a href="showcase1.html">Crypto Wallet Tracker</a></li>
+                        <li><a href="showcase2.html">Enterprise Analytics Dashboard</a></li>
+                    </ul>
+                </li>
+                <li><a href="why-automation.html">Why Automate</a></li>
+                <li><a href="index.html#contact">Contact</a></li>
+                <li><a href="index-he.html">עברית</a></li>
+            </ul>
+        </div>
+    </nav>
     <section class="hero">
         <div class="hero-content">
             <h1>Crypto Wallet Tracker System</h1>
@@ -604,6 +753,25 @@
                     target.scrollIntoView({ behavior: 'smooth' });
                 }
             });
+        });
+    </script>
+    <script>
+        const navToggle = document.getElementById('navToggle');
+        const navLinks = document.querySelector('.nav-links');
+        const submenu = document.querySelector('.submenu');
+        const submenuLink = document.querySelector('.submenu > a');
+        const dropdown = document.querySelector('.submenu .dropdown');
+        navToggle.addEventListener('click', () => {
+            navLinks.classList.toggle('show');
+        });
+        submenuLink.addEventListener('click', (e) => {
+            e.preventDefault();
+            dropdown.classList.toggle('show');
+        });
+        document.addEventListener('click', (e) => {
+            if (!submenu.contains(e.target)) {
+                dropdown.classList.remove('show');
+            }
         });
     </script>
 </body>

--- a/public/showcase2.html
+++ b/public/showcase2.html
@@ -14,6 +14,22 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Enterprise Analytics Dashboard - Advanced Business Intelligence Solution</title>
     <style>
+        :root {
+            --primary: #00e676;
+            --primary-dark: #00c853;
+            --secondary: #448aff;
+            --dark: #0a0a0a;
+            --dark-secondary: #1a1a1a;
+            --dark-tertiary: #2a2a2a;
+            --light: #ffffff;
+            --text-primary: #e0e0e0;
+            --text-secondary: #9e9e9e;
+            --border-color: #333;
+            --accent: #fbbc04;
+            --danger: #ea4335;
+            --gray: #5f6368;
+        }
+
         * {
             margin: 0;
             padding: 0;
@@ -22,9 +38,117 @@
 
         body {
             font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-            background: #0a0a0a;
-            color: #ffffff;
+            background: var(--dark);
+            color: var(--light);
             overflow-x: hidden;
+        }
+
+        nav {
+            position: fixed;
+            top: 0;
+            width: 100%;
+            background: rgba(10, 10, 10, 0.8);
+            backdrop-filter: blur(10px);
+            z-index: 1000;
+            padding: 1rem 0;
+            border-bottom: 1px solid rgba(51, 51, 51, 0.5);
+        }
+        .nav-container {
+            max-width: 1200px;
+            margin: 0 auto;
+            padding: 0 2rem;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+        }
+        .logo {
+            display: flex;
+            align-items: center;
+            gap: 0.75rem;
+            text-decoration: none;
+            color: var(--light);
+            font-size: 1.25rem;
+            font-weight: 600;
+        }
+        .logo svg {
+            width: 40px;
+            height: 40px;
+            border-radius: 8px;
+            background: var(--dark-secondary);
+            padding: 8px;
+            border: 1px solid var(--border-color);
+        }
+        .nav-toggle { display: none; }
+        .nav-links {
+            display: flex;
+            list-style: none;
+            gap: 2.5rem;
+            align-items: center;
+        }
+        .nav-links li { position: relative; }
+        .nav-links a {
+            color: var(--text-secondary);
+            text-decoration: none;
+            font-size: 0.9rem;
+            font-weight: 500;
+            transition: color 0.3s ease;
+            position: relative;
+        }
+        .nav-links a:hover { color: var(--light); }
+        .nav-links a::after {
+            content: '';
+            position: absolute;
+            bottom: -5px;
+            left: 0;
+            width: 0;
+            height: 2px;
+            background: var(--primary);
+            transition: width 0.3s ease;
+        }
+        .nav-links a:hover::after { width: 100%; }
+        .dropdown {
+            display: none;
+            flex-direction: column;
+            position: absolute;
+            top: calc(100% + 0.5rem);
+            left: 0;
+            background: var(--dark-secondary);
+            border: 1px solid var(--border-color);
+            padding: 0.5rem 0;
+            border-radius: 8px;
+            min-width: 200px;
+            z-index: 10;
+        }
+        .dropdown a { padding: 0.5rem 1.5rem; white-space: nowrap; }
+        .dropdown a:hover { background: var(--dark-tertiary); }
+        .dropdown.show { display: flex; }
+        @media (max-width: 768px) {
+            .nav-links {
+                display: none;
+                position: absolute;
+                top: 100%;
+                right: 0;
+                background: var(--dark);
+                flex-direction: column;
+                padding: 1rem 2rem;
+                border: 1px solid var(--border-color);
+            }
+            .nav-links.show { display: flex; }
+            .nav-links .dropdown {
+                position: static;
+                background: transparent;
+                border: none;
+                padding: 0;
+            }
+            .dropdown a { padding: 0.5rem 0; }
+            .nav-toggle {
+                display: block;
+                background: none;
+                border: none;
+                color: var(--light);
+                font-size: 1.5rem;
+                cursor: pointer;
+            }
         }
 
         /* Hero Section */
@@ -362,6 +486,29 @@
     <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-PZ9XZMFL"
     height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
     <!-- End Google Tag Manager (noscript) -->
+    <nav id="navbar">
+        <div class="nav-container">
+            <a href="index.html" class="logo">
+                <svg viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M40 48H8C5.79086 48 4 46.2091 4 44V4C4 1.79086 5.79086 0 8 0H30L44 14V44C44 46.2091 42.2091 48 40 48Z" fill="#2D2D30"/><path d="M30 0L44 14H34C31.7909 14 30 12.2091 30 10V0Z" fill="#424242"/><path d="M22 26L18 30L22 34" stroke="#448aff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/><path d="M30 26L34 30L30 34" stroke="#00e676" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/><path d="M20 40L24 36L28 40" stroke="#fbbc04" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                Automations <span style="color: var(--text-secondary); font-weight: 400;">BY MEIR</span>
+            </a>
+            <button class="nav-toggle" id="navToggle">☰</button>
+            <ul class="nav-links">
+                <li><a href="index.html#services">Services</a></li>
+                <li><a href="index.html#projects">Projects</a></li>
+                <li><a href="automation-playground.html" class="playground-link">Try It Live</a></li>
+                <li class="submenu"><a href="#">Showcases</a>
+                    <ul class="dropdown">
+                        <li><a href="showcase1.html">Crypto Wallet Tracker</a></li>
+                        <li><a href="showcase2.html">Enterprise Analytics Dashboard</a></li>
+                    </ul>
+                </li>
+                <li><a href="why-automation.html">Why Automate</a></li>
+                <li><a href="index.html#contact">Contact</a></li>
+                <li><a href="index-he.html">עברית</a></li>
+            </ul>
+        </div>
+    </nav>
     <!-- Hero Section -->
     <section class="hero">
         <div class="hero-content">
@@ -751,6 +898,25 @@
                 mockup.addEventListener('mouseleave', () => {
                     mockup.style.transform = 'rotateX(5deg)';
                 });
+            }
+        });
+    </script>
+    <script>
+        const navToggle = document.getElementById('navToggle');
+        const navLinks = document.querySelector('.nav-links');
+        const submenu = document.querySelector('.submenu');
+        const submenuLink = document.querySelector('.submenu > a');
+        const dropdown = document.querySelector('.submenu .dropdown');
+        navToggle.addEventListener('click', () => {
+            navLinks.classList.toggle('show');
+        });
+        submenuLink.addEventListener('click', (e) => {
+            e.preventDefault();
+            dropdown.classList.toggle('show');
+        });
+        document.addEventListener('click', (e) => {
+            if (!submenu.contains(e.target)) {
+                dropdown.classList.remove('show');
             }
         });
     </script>

--- a/public/why-automation.html
+++ b/public/why-automation.html
@@ -9,26 +9,105 @@
     <style>
         @import url('https://fonts.googleapis.com/css2?family=Marck+Script&display=swap');
         :root {
-            --primary: #4285F4; --secondary: #34A853; --accent: #FBBC04; --danger: #EA4335;
-            --dark: #202124; --light: #f8f9fa; --gray: #5f6368;
-            --gradient: linear-gradient(135deg, #4285F4 0%, #34A853 100%);
+            --primary: #00e676;
+            --primary-dark: #00c853;
+            --secondary: #448aff;
+            --dark: #0a0a0a;
+            --dark-secondary: #1a1a1a;
+            --dark-tertiary: #2a2a2a;
+            --light: #ffffff;
+            --text-primary: #e0e0e0;
+            --text-secondary: #9e9e9e;
+            --border-color: #333;
+            --accent: #fbbc04;
+            --danger: #ea4335;
+            --gray: #5f6368;
         }
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; background:#000; color:var(--light); margin:0; }
-        nav { position: fixed; top:0; width:100%; background:rgba(32,33,36,0.9); backdrop-filter:blur(10px); z-index:1000; padding:1rem 0; }
-        .nav-container { max-width:1200px; margin:0 auto; padding:0 2rem; display:flex; justify-content:space-between; align-items:center; }
-        .logo { font-family:'Marck Script',cursive; font-size:1.5rem; color:var(--light); text-decoration:none; display:flex; align-items:center; gap:.8rem; }
-        .logo svg { width:3rem; height:3rem; }
-        .nav-toggle { display:none; }
-        .nav-links { display:flex; gap:2rem; list-style:none; }
-        .nav-links li { position:relative; }
-        .nav-links a { color:var(--light); text-decoration:none; position:relative; }
-        .dropdown { display:none; flex-direction:column; position:absolute; top:calc(100% + 0.5rem); left:0; background:rgba(32,33,36,0.9); padding:.5rem 0; border-radius:8px; min-width:250px; }
-        .dropdown.show{display:flex;}
-        .dropdown a{padding:.5rem 1rem; display:block;}
+        nav {
+            position: fixed;
+            top: 0;
+            width: 100%;
+            background: rgba(10, 10, 10, 0.8);
+            backdrop-filter: blur(10px);
+            z-index: 1000;
+            padding: 1rem 0;
+            border-bottom: 1px solid rgba(51, 51, 51, 0.5);
+        }
+        .nav-container {
+            max-width: 1200px;
+            margin: 0 auto;
+            padding: 0 2rem;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+        }
+        .logo {
+            display: flex;
+            align-items: center;
+            gap: 0.75rem;
+            text-decoration: none;
+            color: var(--light);
+            font-size: 1.25rem;
+            font-weight: 600;
+        }
+        .logo svg {
+            width: 40px;
+            height: 40px;
+            border-radius: 8px;
+            background: var(--dark-secondary);
+            padding: 8px;
+            border: 1px solid var(--border-color);
+        }
+        .nav-toggle { display: none; }
+        .nav-links {
+            display: flex;
+            list-style: none;
+            gap: 2.5rem;
+            align-items: center;
+        }
+        .nav-links li { position: relative; }
+        .nav-links a {
+            color: var(--text-secondary);
+            text-decoration: none;
+            font-size: 0.9rem;
+            font-weight: 500;
+            transition: color 0.3s ease;
+            position: relative;
+        }
+        .nav-links a:hover { color: var(--light); }
+        .nav-links a::after {
+            content: '';
+            position: absolute;
+            bottom: -5px;
+            left: 0;
+            width: 0;
+            height: 2px;
+            background: var(--primary);
+            transition: width 0.3s ease;
+        }
+        .nav-links a:hover::after { width: 100%; }
+        .dropdown {
+            display: none;
+            flex-direction: column;
+            position: absolute;
+            top: calc(100% + 0.5rem);
+            left: 0;
+            background: var(--dark-secondary);
+            border: 1px solid var(--border-color);
+            padding: 0.5rem 0;
+            border-radius: 8px;
+            min-width: 200px;
+            z-index: 10;
+        }
+        .dropdown a { padding: 0.5rem 1.5rem; white-space: nowrap; }
+        .dropdown a:hover { background: var(--dark-tertiary); }
+        .dropdown.show { display: flex; }
         @media (max-width:768px){
-            .nav-links{ display:none; position:absolute; top:100%; right:0; background:rgba(32,33,36,0.95); flex-direction:column; gap:1rem; padding:1rem 2rem; }
+            .nav-links{ display:none; position:absolute; top:100%; right:0; background:var(--dark); flex-direction:column; gap:1rem; padding:1rem 2rem; border:1px solid var(--border-color); }
             .nav-links.show{display:flex;}
-            .nav-links .dropdown{position:static; background:transparent; padding:0 0 0 1rem;}
+            .nav-links .dropdown{position:static; background:transparent; border:none; padding:0;}
+            .dropdown a{ padding:0.5rem 0; }
             .nav-toggle{ display:block; background:none; border:none; color:var(--light); font-size:1.5rem; cursor:pointer; }
         }
         article{max-width:800px; margin:6rem auto 2rem; padding:0 1rem; line-height:1.8;}
@@ -40,10 +119,10 @@
     <nav id="navbar">
         <div class="nav-container">
             <a href="index.html" class="logo">
-                <svg viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M40 48H8C5.79086 48 4 46.2091 4 44V4C4 1.79086 5.79086 0 8 0H30L44 14V44C44 46.2091 42.2091 48 40 48Z" fill="#2D2D30"/><path d="M30 0L44 14H34C31.7909 14 30 12.2091 30 10V0Z" fill="#424242"/><path d="M22 26L18 30L22 34" stroke="#4285F4" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/><path d="M30 26L34 30L30 34" stroke="#34A853" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/><path d="M20 40L24 36L28 40" stroke="#FBBC04" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
-                Automation by Meir
+                <svg viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M40 48H8C5.79086 48 4 46.2091 4 44V4C4 1.79086 5.79086 0 8 0H30L44 14V44C44 46.2091 42.2091 48 40 48Z" fill="#2D2D30"/><path d="M30 0L44 14H34C31.7909 14 30 12.2091 30 10V0Z" fill="#424242"/><path d="M22 26L18 30L22 34" stroke="#448aff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/><path d="M30 26L34 30L30 34" stroke="#00e676" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/><path d="M20 40L24 36L28 40" stroke="#fbbc04" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                Automations <span style="color: var(--text-secondary); font-weight: 400;">BY MEIR</span>
             </a>
-            <button class="nav-toggle" id="navToggle">&#9776;</button>
+            <button class="nav-toggle" id="navToggle">☰</button>
             <ul class="nav-links">
                 <li><a href="index.html#services">Services</a></li>
                 <li><a href="index.html#projects">Projects</a></li>
@@ -56,8 +135,9 @@
                 </li>
                 <li><a href="index.html#about">About</a></li>
                 <li><a href="payment.html">Payments</a></li>
-                <li><a href="why-automation.html">Why Automation?</a></li>
+                <li><a href="why-automation.html">Why Automate</a></li>
                 <li><a href="index.html#contact">Contact</a></li>
+                <li><a href="index-he.html">עברית</a></li>
             </ul>
         </div>
     </nav>


### PR DESCRIPTION
## Summary
- add showcases dropdown with two examples
- link to Hebrew site and fix Why Automate navigation
- align other pages with new index design

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68960157275083338e6580051b8bcaae