### PR TITLE
Fix playground action buttons visibility and run trigger

### DIFF
--- a/public/automation-playground.html
+++ b/public/automation-playground.html
@@ -522,11 +522,11 @@
         /* Action Buttons */
         .action-buttons {
             position: fixed;
-            top: 2rem;
+            top: 6rem;
             right: 2rem;
             display: flex;
             gap: 1rem;
-            z-index: 100;
+            z-index: 1100;
         }
 
         .btn {
@@ -1064,7 +1064,7 @@
                 return;
             }
             
-            const runBtn = document.querySelector('.btn-primary');
+            const runBtn = document.querySelector('.action-buttons .btn-primary');
             runBtn.disabled = true;
             runBtn.textContent = 'Running...';
             


### PR DESCRIPTION
## Summary
- Position action buttons below the nav bar with higher z-index
- Scope run automation button selector to action buttons to ensure script triggers

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68967cbe1adc83339aeffb4f3d49a80b