### PR TITLE
Fix Hebrew logo alignment and unify branding

### DIFF
--- a/public/automation-playground.html
+++ b/public/automation-playground.html
@@ -78,14 +78,19 @@
             color: var(--light);
             font-size: 1.25rem;
             font-weight: 600;
+            font-family: 'IBM Plex Sans', sans-serif;
         }
 
         .logo svg {
             width: 40px;
             height: 40px;
             border-radius: 8px;
-            background: var(--dark-secondary);
             padding: 8px;
+        }
+        .logo .by-meir {
+            color: var(--text-secondary);
+            font-weight: 400;
+            font-size: 0.8em;
         }
 
         .nav-toggle {
@@ -627,8 +632,13 @@
     <nav id="navbar">
         <div class="nav-container">
             <a href="index.html" class="logo">
-                <svg viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M40 48H8C5.79086 48 4 46.2091 4 44V4C4 1.79086 5.79086 0 8 0H30L44 14V44C44 46.2091 42.2091 48 40 48Z" fill="#2D2D30"/><path d="M30 0L44 14H34C31.7909 14 30 12.2091 30 10V0Z" fill="#424242"/><path d="M22 26L18 30L22 34" stroke="#448aff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/><path d="M30 26L34 30L30 34" stroke="#00e676" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/><path d="M20 40L24 36L28 40" stroke="#fbbc04" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
-                Automations <span style="color: var(--text-secondary); font-weight: 400;">BY MEIR</span>
+                <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                    <path d="M9 3L5 7L9 11" stroke="#00e676" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+                    <path d="M15 3L19 7L15 11" stroke="#448aff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+                    <path d="M10 14L8 20" stroke="#ffc107" stroke-width="2" stroke-linecap="round"/>
+                    <path d="M16 14L14 20" stroke="#ffc107" stroke-width="2" stroke-linecap="round"/>
+                </svg>
+                Automations <span class="by-meir">by Meir</span>
             </a>
             <button class="nav-toggle" id="navToggle">☰</button>
             <ul class="nav-links">

--- a/public/index-he.html
+++ b/public/index-he.html
@@ -16,6 +16,7 @@
     <meta name="description" content="פתרונות אוטומציה מותאמים אישית לעסק שלכם" />
     <link rel="canonical" href="https://automationbymeir.web.app/index-he.html" />
     <style>
+        @import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@200;300;400;500;600;700&display=swap');
         @import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Sans+Hebrew:wght@200;300;400;500;600;700&display=swap');
         :root {
             --primary: #00e676;
@@ -76,8 +77,23 @@
         @keyframes float { from { transform: translateY(100vh) translateX(0); } to { transform: translateY(-100px) translateX(100px); } }
         nav { position: fixed; top: 0; width: 100%; background: rgba(10, 10, 10, 0.8); backdrop-filter: blur(10px); z-index: 1000; padding: 1rem 0; border-bottom: 1px solid rgba(51, 51, 51, 0.5); }
         .nav-container { max-width: 1200px; margin: 0 auto; padding: 0 2rem; display: flex; justify-content: space-between; align-items: center; }
-        .logo { font-size: 1.25rem; font-weight: 600; color: var(--light); text-decoration: none; display: flex; align-items: center; gap: 0.75rem; font-family: 'IBM Plex Sans Hebrew', sans-serif; }
+        .logo {
+            font-size: 1.25rem;
+            font-weight: 600;
+            color: var(--light);
+            text-decoration: none;
+            display: flex;
+            align-items: center;
+            gap: 0.75rem;
+            font-family: 'IBM Plex Sans', 'IBM Plex Sans Hebrew', sans-serif;
+            direction: ltr;
+        }
         .logo svg { width: 40px; height: 40px; }
+        .logo .by-meir {
+            color: var(--text-secondary);
+            font-weight: 400;
+            font-size: 0.8em;
+        }
         .nav-toggle { display: none; }
         .nav-links { display: flex; gap: 2rem; list-style: none; padding-right: 0; }
         .nav-links a { color: var(--text-secondary); text-decoration: none; transition: all 0.3s ease; position: relative; font-size: 0.9rem; font-weight: 500; }
@@ -208,7 +224,7 @@
                     <path d="M16 14L14 20" stroke="#ffc107" stroke-width="2" stroke-linecap="round"/>
                 </svg>
                 Automations
-                <span style="color: var(--text-secondary); font-weight: 400;">BY MEIR</span>
+                <span class="by-meir">by Meir</span>
             </a>
             <button class="nav-toggle" id="navToggle">&#9776;</button>
             <ul class="nav-links">

--- a/public/index.html
+++ b/public/index.html
@@ -90,6 +90,11 @@
             border-radius: 8px;
             padding: 8px;
         }
+        .logo .by-meir {
+            color: var(--text-secondary);
+            font-weight: 400;
+            font-size: 0.8em;
+        }
         
         .nav-toggle {
             display: none;
@@ -731,7 +736,7 @@
                     <path d="M16 14L14 20" stroke="#ffc107" stroke-width="2" stroke-linecap="round"/>
                 </svg>
                 Automations
-                <span style="color: var(--text-secondary); font-weight: 400;">BY MEIR</span>
+                <span class="by-meir">by Meir</span>
             </a>
             <button class="nav-toggle" id="navToggle">☰</button>
             <ul class="nav-links">

--- a/public/payment.html
+++ b/public/payment.html
@@ -79,13 +79,18 @@
             color: var(--light);
             font-size: 1.25rem;
             font-weight: 600;
+            font-family: 'IBM Plex Sans', sans-serif;
         }
         .logo svg {
             width: 40px;
             height: 40px;
             border-radius: 8px;
-            background: var(--dark-secondary);
             padding: 8px;
+        }
+        .logo .by-meir {
+            color: var(--text-secondary);
+            font-weight: 400;
+            font-size: 0.8em;
         }
         .nav-toggle {
             display: none;
@@ -277,8 +282,13 @@
     <nav id="navbar">
         <div class="nav-container">
             <a href="index.html" class="logo">
-                <svg viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M40 48H8C5.79086 48 4 46.2091 4 44V4C4 1.79086 5.79086 0 8 0H30L44 14V44C44 46.2091 42.2091 48 40 48Z" fill="#2D2D30"/><path d="M30 0L44 14H34C31.7909 14 30 12.2091 30 10V0Z" fill="#424242"/><path d="M22 26L18 30L22 34" stroke="#448aff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/><path d="M30 26L34 30L30 34" stroke="#00e676" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/><path d="M20 40L24 36L28 40" stroke="#fbbc04" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
-                Automations <span style="color: var(--text-secondary); font-weight: 400;">BY MEIR</span>
+                <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                    <path d="M9 3L5 7L9 11" stroke="#00e676" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+                    <path d="M15 3L19 7L15 11" stroke="#448aff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+                    <path d="M10 14L8 20" stroke="#ffc107" stroke-width="2" stroke-linecap="round"/>
+                    <path d="M16 14L14 20" stroke="#ffc107" stroke-width="2" stroke-linecap="round"/>
+                </svg>
+                Automations <span class="by-meir">by Meir</span>
             </a>
             <button class="nav-toggle" id="navToggle">☰</button>
             <ul class="nav-links">

--- a/public/showcase1.html
+++ b/public/showcase1.html
@@ -72,13 +72,18 @@
             color: var(--light);
             font-size: 1.25rem;
             font-weight: 600;
+            font-family: 'IBM Plex Sans', sans-serif;
         }
         .logo svg {
             width: 40px;
             height: 40px;
             border-radius: 8px;
-            background: var(--dark-secondary);
             padding: 8px;
+        }
+        .logo .by-meir {
+            color: var(--text-secondary);
+            font-weight: 400;
+            font-size: 0.8em;
         }
         .nav-toggle { display: none; }
         .nav-links {
@@ -370,8 +375,13 @@
     <nav id="navbar">
         <div class="nav-container">
             <a href="index.html" class="logo">
-                <svg viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M40 48H8C5.79086 48 4 46.2091 4 44V4C4 1.79086 5.79086 0 8 0H30L44 14V44C44 46.2091 42.2091 48 40 48Z" fill="#2D2D30"/><path d="M30 0L44 14H34C31.7909 14 30 12.2091 30 10V0Z" fill="#424242"/><path d="M22 26L18 30L22 34" stroke="#448aff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/><path d="M30 26L34 30L30 34" stroke="#00e676" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/><path d="M20 40L24 36L28 40" stroke="#fbbc04" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
-                Automations <span style="color: var(--text-secondary); font-weight: 400;">BY MEIR</span>
+                <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                    <path d="M9 3L5 7L9 11" stroke="#00e676" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+                    <path d="M15 3L19 7L15 11" stroke="#448aff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+                    <path d="M10 14L8 20" stroke="#ffc107" stroke-width="2" stroke-linecap="round"/>
+                    <path d="M16 14L14 20" stroke="#ffc107" stroke-width="2" stroke-linecap="round"/>
+                </svg>
+                Automations <span class="by-meir">by Meir</span>
             </a>
             <button class="nav-toggle" id="navToggle">☰</button>
             <ul class="nav-links">

--- a/public/showcase2.html
+++ b/public/showcase2.html
@@ -74,13 +74,18 @@
             color: var(--light);
             font-size: 1.25rem;
             font-weight: 600;
+            font-family: 'IBM Plex Sans', sans-serif;
         }
         .logo svg {
             width: 40px;
             height: 40px;
             border-radius: 8px;
-            background: var(--dark-secondary);
             padding: 8px;
+        }
+        .logo .by-meir {
+            color: var(--text-secondary);
+            font-weight: 400;
+            font-size: 0.8em;
         }
         .nav-toggle { display: none; }
         .nav-links {
@@ -493,8 +498,13 @@
     <nav id="navbar">
         <div class="nav-container">
             <a href="index.html" class="logo">
-                <svg viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M40 48H8C5.79086 48 4 46.2091 4 44V4C4 1.79086 5.79086 0 8 0H30L44 14V44C44 46.2091 42.2091 48 40 48Z" fill="#2D2D30"/><path d="M30 0L44 14H34C31.7909 14 30 12.2091 30 10V0Z" fill="#424242"/><path d="M22 26L18 30L22 34" stroke="#448aff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/><path d="M30 26L34 30L30 34" stroke="#00e676" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/><path d="M20 40L24 36L28 40" stroke="#fbbc04" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
-                Automations <span style="color: var(--text-secondary); font-weight: 400;">BY MEIR</span>
+                <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                    <path d="M9 3L5 7L9 11" stroke="#00e676" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+                    <path d="M15 3L19 7L15 11" stroke="#448aff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+                    <path d="M10 14L8 20" stroke="#ffc107" stroke-width="2" stroke-linecap="round"/>
+                    <path d="M16 14L14 20" stroke="#ffc107" stroke-width="2" stroke-linecap="round"/>
+                </svg>
+                Automations <span class="by-meir">by Meir</span>
             </a>
             <button class="nav-toggle" id="navToggle">☰</button>
             <ul class="nav-links">

--- a/public/why-automation-he.html
+++ b/public/why-automation-he.html
@@ -7,6 +7,7 @@
     <meta name="description" content="כיצד אוטומציה משפרת יעילות וצמיחה" />
     <link rel="canonical" href="https://automationbymeir.web.app/why-automation-he.html" />
     <style>
+        @import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@200;400;600;700&display=swap');
         @import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Sans+Hebrew:wght@200;400;600;700&display=swap');
         :root {
             --primary: #00e676;
@@ -27,8 +28,23 @@
         h1 { font-weight: 200; font-family: 'IBM Plex Sans Hebrew', sans-serif; }
         nav { position: fixed; top:0; width:100%; background:rgba(10, 10, 10, 0.8); backdrop-filter:blur(10px); z-index:1000; padding:1rem 0; border-bottom:1px solid rgba(51, 51, 51, 0.5); }
         .nav-container { max-width:1200px; margin:0 auto; padding:0 2rem; display:flex; justify-content:space-between; align-items:center; }
-        .logo { font-size:1.25rem; font-weight:600; color:var(--light); text-decoration:none; display:flex; align-items:center; gap:.75rem; font-family: 'IBM Plex Sans Hebrew', sans-serif; }
+        .logo {
+            font-size:1.25rem;
+            font-weight:600;
+            color:var(--light);
+            text-decoration:none;
+            display:flex;
+            align-items:center;
+            gap:.75rem;
+            font-family: 'IBM Plex Sans', 'IBM Plex Sans Hebrew', sans-serif;
+            direction:ltr;
+        }
         .logo svg { width:40px; height:40px; }
+        .logo .by-meir {
+            color:var(--text-secondary);
+            font-weight:400;
+            font-size:0.8em;
+        }
         .nav-toggle { display:none; }
         .nav-links { display:flex; gap:2rem; list-style:none; }
         .nav-links li { position:relative; }
@@ -68,7 +84,7 @@
                     <path d="M16 14L14 20" stroke="#ffc107" stroke-width="2" stroke-linecap="round"/>
                 </svg>
                 Automations
-                <span style="color: var(--text-secondary); font-weight: 400;">BY MEIR</span>
+                <span class="by-meir">by Meir</span>
             </a>
         </div>
     </nav>

--- a/public/why-automation.html
+++ b/public/why-automation.html
@@ -51,13 +51,18 @@
             color: var(--light);
             font-size: 1.25rem;
             font-weight: 600;
+            font-family: 'IBM Plex Sans', sans-serif;
         }
         .logo svg {
             width: 40px;
             height: 40px;
             border-radius: 8px;
-            background: var(--dark-secondary);
             padding: 8px;
+        }
+        .logo .by-meir {
+            color: var(--text-secondary);
+            font-weight: 400;
+            font-size: 0.8em;
         }
         .nav-toggle { display: none; }
         .nav-links {
@@ -119,8 +124,13 @@
     <nav id="navbar">
         <div class="nav-container">
             <a href="index.html" class="logo">
-                <svg viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M40 48H8C5.79086 48 4 46.2091 4 44V4C4 1.79086 5.79086 0 8 0H30L44 14V44C44 46.2091 42.2091 48 40 48Z" fill="#2D2D30"/><path d="M30 0L44 14H34C31.7909 14 30 12.2091 30 10V0Z" fill="#424242"/><path d="M22 26L18 30L22 34" stroke="#448aff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/><path d="M30 26L34 30L30 34" stroke="#00e676" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/><path d="M20 40L24 36L28 40" stroke="#fbbc04" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
-                Automations <span style="color: var(--text-secondary); font-weight: 400;">BY MEIR</span>
+                <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                    <path d="M9 3L5 7L9 11" stroke="#00e676" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+                    <path d="M15 3L19 7L15 11" stroke="#448aff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+                    <path d="M10 14L8 20" stroke="#ffc107" stroke-width="2" stroke-linecap="round"/>
+                    <path d="M16 14L14 20" stroke="#ffc107" stroke-width="2" stroke-linecap="round"/>
+                </svg>
+                Automations <span class="by-meir">by Meir</span>
             </a>
             <button class="nav-toggle" id="navToggle">☰</button>
             <ul class="nav-links">


### PR DESCRIPTION
## Summary
- Ensure Hebrew navigation logo reads 'Automations by Meir' with IBM Plex Sans and smaller byline
- Replace all page logos with unified background-free SVG
- Style logo subtitle consistently across site

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_689680eb9f848333a910db45427710e2