### PR TITLE
Fix platform tooltip and add favicon

### DIFF
--- a/dist/automation-playground.html
+++ b/dist/automation-playground.html
@@ -13,6 +13,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Automation Puzzle - Build Your Perfect Workflow</title>
+    <link rel="icon" href="/profile.jpeg" type="image/jpeg">
     <style>
         @import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@200;400;600;700&display=swap');
 

--- a/dist/index-he.html
+++ b/dist/index-he.html
@@ -13,11 +13,13 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Automation by Meir - הפכו את העסק שלכם לאוטומטי וחכם</title>
+    <link rel="icon" href="/profile.jpeg" type="image/jpeg">
     <meta name="description" content="פתרונות אוטומציה מותאמים אישית לעסק שלכם" />
     <link rel="canonical" href="https://automationbymeir.web.app/index-he.html" />
     <style>
         @import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@200;300;400;500;600;700&display=swap');
         @import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Sans+Hebrew:wght@200;300;400;500;600;700&display=swap');
+        @import url('https://fonts.googleapis.com/css2?family=Orbitron:wght@600&display=swap');
         :root {
             --primary: #00e676;
             --primary-dark: #00c853;
@@ -160,6 +162,10 @@
         .service-card:hover, .project-card:hover { transform: translateY(-10px); border-color: var(--primary); box-shadow: 0 20px 40px rgba(66, 133, 244, 0.3); }
         .service-title { font-size: 1.5rem; margin-bottom: 1rem; color: var(--secondary); }
         .service-description, .project-description, .about-text, .stat-label { color: #cbd5e1; }
+        .project-logo { height: 40px; width: auto; }
+        .project-logo-text { font-family: 'Orbitron', sans-serif; font-weight: 600; color: var(--primary); text-decoration: none; }
+        .read-more { color: var(--primary); text-decoration: none; font-weight: 500; margin-top: 1rem; display: inline-block; }
+        .read-more:hover { text-decoration: underline; }
         .project-header { padding: 2rem; background: rgba(66, 133, 244, 0.1); }
         .project-title { font-size: 1.5rem; color: var(--light); margin-bottom: 0.5rem; }
         .project-tech { display: flex; gap: 0.5rem; flex-wrap: wrap; justify-content: flex-start; }
@@ -169,7 +175,7 @@
         .about-header { display: flex; align-items: center; gap: 3rem; margin-bottom: 3rem; flex-direction: row-reverse; }
         .profile-photo { width: 150px; height: 150px; border-radius: 50%; border: 3px solid var(--primary); overflow: hidden; flex-shrink: 0; }
         .profile-photo img { width: 100%; height: 100%; object-fit: cover; }
-        .about-text { font-size: 1.2rem; line-height: 2; }
+        .about-text { font-size: 1.2rem; line-height: 2; text-align: right; }
         .stats-grid { margin-top: 3rem; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); }
         .stat-card { text-align: center; padding: 2rem; background: var(--dark-secondary); border: 1px solid var(--border-color); border-radius: 0; transition: transform 0.3s ease; }
         .stat-card:hover { transform: translateY(-5px); }
@@ -182,7 +188,7 @@
         .playground-section { position: relative; overflow: hidden; }
         .playground-section::before { content: ''; position: absolute; top: -50%; left: -50%; width: 200%; height: 200%; background: radial-gradient(circle, rgba(66, 133, 244, 0.05) 0%, transparent 50%); animation: rotate 30s linear infinite; }
         .platform-logos { display: flex; flex-wrap: wrap; gap: 1rem; justify-content: center; align-items: center; margin-bottom: 2rem; }
-        .platform-logos img { height: 40px; }
+        .platform-logos img { height: 40px; filter: none; }
         .linkedin-logo { width: 24px; margin-right: 0.5rem; vertical-align: middle; }
         @keyframes rotate { from { transform: rotate(0deg); } to { transform: rotate(360deg); } }
         @media (max-width: 768px) {
@@ -276,12 +282,12 @@
             <div class="platforms">
                 <h3 class="platforms-title">המערכות שאיתן אנחנו בונים אוטומציות</h3>
                 <div class="platform-logos">
-                    <img src="logos/googleappsscript.svg" alt="Google Apps Script">
-                    <img src="logos/firebase.svg" alt="Firebase">
-                    <img src="logos/openai.svg" alt="OpenAI">
-                    <img src="logos/claude.svg" alt="Claude">
-                    <img src="logos/googlegemini.svg" alt="Gemini">
-                    <img src="logos/grok.svg" alt="Grok">
+                    <img src="logos/googleappsscript.svg" alt="Google Apps Script" title="Extend Google Workspace with custom scripts">
+                    <img src="logos/firebase.svg" alt="Firebase" title="Backend services and hosting">
+                    <img src="logos/openai.svg" alt="OpenAI" title="Advanced language model APIs">
+                    <img src="logos/claude.svg" alt="Claude" title="Anthropic's powerful AI assistant">
+                    <img src="logos/googlegemini.svg" alt="Gemini" title="Google's multimodal AI platform">
+                    <img src="logos/grok.svg" alt="Grok" title="Real-time AI from xAI">
                 </div>
             </div>
             <div class="services-grid">
@@ -355,6 +361,18 @@
                         <p class="project-description">אוטומציה מלאה של תהליך בדיקת הממליצים, כולל רצפי דוא"ל חכמים ומעקב אחר תגובות.</p>
                     </div>
                 </div>
+                <div class="project-card">
+                    <div class="project-header">
+                        <h3 class="project-title">
+                            <a href="https://www.trendingtechdaily.com/" target="_blank" class="project-logo-text">
+                                TrendingTech Daily
+                            </a>
+                        </h3>
+                    </div>
+                    <div class="project-body">
+                        <p class="project-description">אתר חדשות טכנולוגיה יומי המספק תובנות על טכנולוגיות מתפתחות.</p>
+                    </div>
+                </div>
             </div>
         </div>
     </section>
@@ -372,13 +390,14 @@
                     </div>
                     <div>
                         <p class="about-text">
-                            עם ניסיון של מעל 5 שנים באוטומציה ופיתוח, אני מתמחה ביצירת פתרונות מותאמים אישית שמשנים את אופן הפעולה של עסקים. הגישה שלי של "הכל אפשרי" והמומחיות העמוקה שלי ב-Google Apps Script, Firebase וטכנולוגיות ווב מודרניות מאפשרות לי להתמודד עם האתגרים המורכבים ביותר.
+                            עם ניסיון של מעל 8 שנים באוטומציה ופיתוח, אני בונה פתרונות מותאמים אישית שמשלבים בינה מלאכותית ומשנים את אופן הפעולה של עסקים. המומחיות שלי ב-Google Apps Script, Firebase, טכנולוגיות ווב מודרניות ותהליכי AI מאפשרת לי להתמודד עם האתגרים המורכבים ביותר.
                         </p>
+                        <a href="about-me-he.html" class="read-more">קראו עוד</a>
                     </div>
                 </div>
                 <div class="stats-grid">
                     <div class="stat-card">
-                        <div class="stat-number">5+</div>
+                        <div class="stat-number">8+</div>
                         <div class="stat-label">שנות ניסיון</div>
                     </div>
                     <div class="stat-card">

--- a/dist/index.html
+++ b/dist/index.html
@@ -12,6 +12,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Automations by Meir - Transform Your Business with Intelligent Automation</title>
+    <link rel="icon" href="/profile.jpeg" type="image/jpeg">
     <meta name="description" content="Custom Google Apps Script & Firebase Solutions That Scale. Streamline workflows with intelligent automation." />
     <link rel="canonical" href="https://automationbymeir.web.app/" />
     <style>
@@ -358,7 +359,6 @@
         .platform-logos img {
             height: 40px;
             filter: none;
-            cursor: help;
         }
 
         .linkedin-logo {

--- a/dist/payment.html
+++ b/dist/payment.html
@@ -13,13 +13,13 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Secure Payment - Automation by Meir</title>
+    <link rel="icon" href="/profile.jpeg" type="image/jpeg">
     <meta name="description" content="Complete your payment securely using PayPal." />
     <link rel="canonical" href="https://automationbymeir.web.app/payment.html" />
-    <link rel="icon" type="image/x-icon" href="/favicon.ico">
     <link rel="stylesheet" type="text/css" href="https://www.paypalobjects.com/webstatic/en_US/developer/docs/css/cardfields.css" />
     <style>
         /* Your existing CSS - No changes made */
-        @import url('https://fonts.googleapis.com/css2?family=Marck+Script&display=swap');
+        @import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@200;400;600;700&display=swap');
         :root {
             --primary: #00e676;
             --primary-dark: #00c853;
@@ -36,8 +36,12 @@
             --gray: #5f6368;
         }
         body {
-            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            font-family: 'IBM Plex Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
             background: #000; color: var(--light); min-height: 100vh; overflow-x: hidden;
+        }
+
+        h1 {
+            font-weight: 200;
         }
         .bg-animation {
             position: fixed; width: 100%; height: 100%; top: 0; left: 0; z-index: -1;
@@ -75,14 +79,18 @@
             color: var(--light);
             font-size: 1.25rem;
             font-weight: 600;
+            font-family: 'IBM Plex Sans', sans-serif;
         }
         .logo svg {
             width: 40px;
             height: 40px;
             border-radius: 8px;
-            background: var(--dark-secondary);
             padding: 8px;
-            border: 1px solid var(--border-color);
+        }
+        .logo .by-meir {
+            color: var(--text-secondary);
+            font-weight: 400;
+            font-size: 0.8em;
         }
         .nav-toggle {
             display: none;
@@ -274,8 +282,13 @@
     <nav id="navbar">
         <div class="nav-container">
             <a href="index.html" class="logo">
-                <svg viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M40 48H8C5.79086 48 4 46.2091 4 44V4C4 1.79086 5.79086 0 8 0H30L44 14V44C44 46.2091 42.2091 48 40 48Z" fill="#2D2D30"/><path d="M30 0L44 14H34C31.7909 14 30 12.2091 30 10V0Z" fill="#424242"/><path d="M22 26L18 30L22 34" stroke="#448aff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/><path d="M30 26L34 30L30 34" stroke="#00e676" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/><path d="M20 40L24 36L28 40" stroke="#fbbc04" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
-                Automations <span style="color: var(--text-secondary); font-weight: 400;">BY MEIR</span>
+                <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                    <path d="M9 3L5 7L9 11" stroke="#00e676" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+                    <path d="M15 3L19 7L15 11" stroke="#448aff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+                    <path d="M10 14L8 20" stroke="#ffc107" stroke-width="2" stroke-linecap="round"/>
+                    <path d="M16 14L14 20" stroke="#ffc107" stroke-width="2" stroke-linecap="round"/>
+                </svg>
+                Automations <span class="by-meir">by Meir</span>
             </a>
             <button class="nav-toggle" id="navToggle">☰</button>
             <ul class="nav-links">
@@ -289,6 +302,7 @@
                     </ul>
                 </li>
                 <li><a href="why-automation.html">Why Automate</a></li>
+                <li><a href="payment.html">Payments</a></li>
                 <li><a href="index.html#contact">Contact</a></li>
                 <li><a href="index-he.html">עברית</a></li>
             </ul>

--- a/dist/services/ai-powered-systems.html
+++ b/dist/services/ai-powered-systems.html
@@ -3,14 +3,22 @@
 <head>
 <meta charset="UTF-8">
 <title>AI-Powered Systems | Automations by Meir</title>
+    <link rel="icon" href="/profile.jpeg" type="image/jpeg">
 <style>
  body { font-family: 'IBM Plex Sans', sans-serif; background:#0a0a0a; color:#e0e0e0; padding:2rem; }
  a { color:#00e676; }
+ p { margin-bottom:1rem; }
 </style>
 </head>
 <body>
 <a href="../index.html">&larr; Back to Home</a>
 <h1>AI-Powered Systems</h1>
-<p>Custom AI agents, LLM integrations, and intelligent automation systems that understand and adapt to your business needs.</p>
+<p>Artificial intelligence is reshaping how modern organizations operate, and our AI-powered systems are designed to bring that transformation directly into your daily workflow. Whether you need virtual assistants that understand context, automation that reasons about complex data, or machine learning models that continuously improve, we build solutions that put intelligent behavior at the core of your business processes. Every project begins with a deep dive into your goals so that the resulting system feels tailored rather than generic.</p>
+<p>Our approach relies on a combination of large language models and domain-specific logic to create agents that can plan, converse, and execute tasks on your behalf. By orchestrating models such as GPT, Claude, and Gemini together with traditional APIs and databases, we create hybrid systems that understand natural language yet remain grounded in reliable data. This architecture means that your AI agents can draft emails, summarize reports, or trigger downstream actions while staying aligned with your policies and tone.</p>
+<p>A key differentiator of our work is the emphasis on customization. Off-the-shelf chatbots often struggle in real environments because they are not trained on your vocabulary or company rules. We enrich models with retrieval mechanisms, embeddings, and lightweight fine-tuning so that they can reference your documents, past interactions, or product catalogs. The result is an assistant that knows your clients, remembers previous conversations, and can surface exactly the right information at the right moment.</p>
+<p>Security and governance are built into every layer. We implement robust authentication, rate limiting, and detailed logging so that you always know who triggered what action and why. Sensitive data can be masked or encrypted before it leaves your environment, and each model call is carefully scoped to minimize exposure. If compliance requirements change, the modular design of our systems allows individual components to be swapped or upgraded without disrupting the entire workflow.</p>
+<p>Because AI is only as valuable as the decisions it enables, we pay special attention to monitoring and feedback loops. Dashboards highlight model performance, user satisfaction, and cost metrics in real time. When an agent makes a mistake or encounters an unexpected scenario, administrators can review the conversation, adjust prompts, or retrain relevant components. This iterative cycle ensures that the system grows more accurate and aligned with your objectives over time.</p>
+<p>Scalability is another cornerstone. Our deployments take advantage of serverless platforms, containerization, and managed orchestration tools so that your AI infrastructure can handle sudden spikes in usage without manual intervention. Whether your team has ten users or ten thousand, the system automatically allocates resources, balances workloads, and maintains responsive performance. You focus on the insights, and the infrastructure quietly scales in the background.</p>
+<p>Investing in AI-powered systems is ultimately about unlocking new value: reducing repetitive work, discovering hidden patterns, and delighting customers with experiences that feel almost magical. By partnering with Automations by Meir, you gain a team that understands both the promise and the practicalities of intelligent automation. Reach out today to explore how a custom agent or workflow can become the most versatile member of your organization.</p>
 </body>
 </html>

--- a/dist/services/api-integration.html
+++ b/dist/services/api-integration.html
@@ -3,14 +3,22 @@
 <head>
 <meta charset="UTF-8">
 <title>API Integration | Automations by Meir</title>
+    <link rel="icon" href="/profile.jpeg" type="image/jpeg">
 <style>
  body { font-family: 'IBM Plex Sans', sans-serif; background:#0a0a0a; color:#e0e0e0; padding:2rem; }
  a { color:#00e676; }
+ p { margin-bottom:1rem; }
 </style>
 </head>
 <body>
 <a href="../index.html">&larr; Back to Home</a>
 <h1>API Integration</h1>
-<p>Seamlessly connect multiple platforms, LLMs, and services to create powerful integrated solutions.</p>
+<p>Modern businesses rely on an ecosystem of specialized tools: CRMs, marketing platforms, payment processors, and AI services, just to name a few. Our API integration service connects these disparate systems so data moves freely and processes run without manual intervention. Instead of copy-pasting information between apps, your team can trust that updates propagate automatically and that every system has a consistent picture of your operations.</p>
+<p>The first step in any integration project is understanding the vocabulary of each platform. APIs speak different dialects, using unique authentication schemes, rate limits, and data structures. We audit the documentation, identify potential conflicts, and design an architecture that minimizes latency while maximizing reliability. Wherever possible, we use standardized protocols such as REST, GraphQL, or gRPC, but we are equally comfortable working with proprietary interfaces when the use case demands it.</p>
+<p>Once the blueprint is in place, we develop connectors that transform and route data between services. These connectors can run on serverless functions, dedicated servers, or even within Google Apps Script depending on scale and budget. Error handling and retry logic are built in from the start, ensuring that transient outages or malformed responses do not corrupt downstream processes. Logging and alerting allow administrators to monitor the health of each integration and respond quickly if an issue arises.</p>
+<p>Security is paramount when systems begin to share data. OAuth flows, API keys, and access tokens are stored securely, often using managed secrets services or encrypted environment variables. We enforce the principle of least privilege, granting each connector only the permissions it truly needs. When required, sensitive fields can be hashed or masked before leaving your infrastructure, and all network communication is performed over TLS with certificate validation.</p>
+<p>Beyond simple data synchronization, our integrations often orchestrate complex business logic. For example, a new lead captured on your website can automatically create a contact in the CRM, send a personalized email, generate a task for the sales team, and record the interaction in an analytics platform—all within seconds. Workflows like these reduce response times and ensure that no opportunity falls through the cracks.</p>
+<p>We also recognize that APIs evolve. Version changes, deprecations, and new features can break existing integrations if they are not proactively managed. Our maintenance plans include periodic reviews of vendor roadmaps and automated tests that simulate real-world usage. When an update is required, we schedule it during low-impact windows and provide clear communication so your team is never caught off guard.</p>
+<p>The end result is a digital infrastructure where systems collaborate seamlessly. Employees spend less time on administrative chores and more time on high-impact work. Customers enjoy faster service, and executives gain a unified dataset that supports accurate reporting and predictive analytics. With Automations by Meir handling your API integrations, you can expand your toolset without introducing chaos.</p>
 </body>
 </html>

--- a/dist/services/data-dashboards.html
+++ b/dist/services/data-dashboards.html
@@ -3,14 +3,22 @@
 <head>
 <meta charset="UTF-8">
 <title>Data Dashboards | Automations by Meir</title>
+    <link rel="icon" href="/profile.jpeg" type="image/jpeg">
 <style>
  body { font-family: 'IBM Plex Sans', sans-serif; background:#0a0a0a; color:#e0e0e0; padding:2rem; }
  a { color:#00e676; }
+ p { margin-bottom:1rem; }
 </style>
 </head>
 <body>
 <a href="../index.html">&larr; Back to Home</a>
 <h1>Data Dashboards</h1>
-<p>Beautiful, interactive dashboards that transform spreadsheet data into actionable insights with stunning visualizations.</p>
+<p>Information is only useful when it is clear, accessible, and timely. Our data dashboards transform raw numbers into vivid narratives that guide decision makers at every level of your organization. Instead of scrolling through endless spreadsheets, you can open a single page that highlights trends, anomalies, and opportunities in real time. Each dashboard is built with your unique objectives in mind, making it far more than a generic reporting tool.</p>
+<p>We start every engagement by mapping the data sources that matter most. Google Sheets, SQL databases, CRM systems, and even custom APIs can all feed into a unified model. Through automated refresh cycles and webhooks, the dashboard stays synchronized with the latest information so you never have to wonder if you are looking at yesterday's numbers. When a stakeholder needs to drill deeper, interactive filters and drill-down views reveal the full context behind each metric.</p>
+<p>Visual design plays a critical role in comprehension, which is why we pay as much attention to aesthetics as to accuracy. Charts are styled to match your brand and to emphasize the story behind the data. Heat maps, dynamic tables, and geospatial visualizations bring complex relationships to life, while responsive layouts ensure the experience looks great on desktops, tablets, or phones. For teams working in different languages or regions, localized labels and currency formatting can be applied without duplicating the entire dashboard.</p>
+<p>Security and performance are central to our implementation. Access controls can be tied to individual user roles, ensuring that sensitive figures remain private. Dashboards can be embedded within internal portals or shared via secure links, and each query is optimized to minimize load times even for large datasets. Where appropriate, cached layers and incremental updates reduce the strain on upstream systems while still delivering fresh insights.</p>
+<p>Automation adds another layer of value. Threshold-based alerts can notify managers when key indicators cross a predefined limit, prompting action before a minor issue becomes a major problem. Scheduled email reports summarize the latest trends for stakeholders who prefer a snapshot in their inbox. For organizations with complex workflows, dashboard actions can trigger external scripts or integrate with tools like Slack, Trello, or Google Workspace to keep everyone aligned.</p>
+<p>We recognize that a dashboard is not a one-time deliverable but a living product. As your business evolves, new metrics become relevant and old ones fade. Our maintenance plans include iterative enhancements, user training sessions, and periodic data quality audits to ensure that the dashboard continues to earn its place at the center of your operations. Feedback loops allow users to request new views or clarifications, keeping the interface intuitive and the data trustworthy.</p>
+<p>The ultimate goal of our data dashboards is to empower confident, data-driven decisions. When leadership can see a holistic picture of revenue, operations, and customer behavior, they can pivot strategies quickly and with conviction. By eliminating manual reporting chores and presenting insights in a digestible format, your team gains time to focus on strategic thinking rather than data wrangling. Let Automations by Meir build the dashboard that becomes the heartbeat of your organization.</p>
 </body>
 </html>

--- a/dist/services/document-generation.html
+++ b/dist/services/document-generation.html
@@ -3,14 +3,22 @@
 <head>
 <meta charset="UTF-8">
 <title>Document Generation | Automations by Meir</title>
+    <link rel="icon" href="/profile.jpeg" type="image/jpeg">
 <style>
  body { font-family: 'IBM Plex Sans', sans-serif; background:#0a0a0a; color:#e0e0e0; padding:2rem; }
  a { color:#00e676; }
+ p { margin-bottom:1rem; }
 </style>
 </head>
 <body>
 <a href="../index.html">&larr; Back to Home</a>
 <h1>Document Generation</h1>
-<p>Dynamic PDF creation systems with custom parameters, graphics, and professional layouts.</p>
+<p>From invoices and contracts to certificates and customized reports, businesses produce a staggering number of documents. Automating that creation process saves time and eliminates the inconsistencies that arise from manual editing. Our document generation service builds templates that merge data from your systems with polished layouts, resulting in professional files that are ready to share the moment they are created.</p>
+<p>We begin by analyzing the documents you produce most frequently. This includes reviewing branding guidelines, required fields, and any regulatory language that must appear in every version. Using tools like Google Docs, PDF libraries, and HTML-to-PDF converters, we create templates that separate design from data. Updates to wording or formatting can be made centrally, ensuring that every future document reflects the change without revisiting old files.</p>
+<p>Data can flow into these templates from spreadsheets, databases, or web forms. Scripts validate the inputs, apply conditional logic, and insert images or signatures where necessary. For example, an invoice might automatically pull line items from a sales sheet, calculate taxes, and include a personalized note for the client. Output formats range from PDF and DOCX to dynamic HTML views that users can edit before finalizing.</p>
+<p>Delivery options are equally flexible. Generated documents can be emailed to recipients, stored in cloud drives, or sent to printers without human involvement. Versioning and archival features make it easy to retrieve past records for audits or customer service inquiries. When a document needs approval, the workflow can route it to the appropriate supervisor and track the decision, creating a clear audit trail.</p>
+<p>Security and compliance are treated with utmost care. Sensitive information can be redacted or encrypted, and access to templates or output files can be restricted based on user roles. We adhere to best practices for data retention, ensuring that temporary files are deleted and that logs avoid exposing confidential details. For industries with strict regulations, such as finance or healthcare, we tailor solutions to meet applicable standards.</p>
+<p>The efficiency gains are immediate. Staff no longer waste hours copying data into word processors or reformatting spreadsheets. Instead, they trigger a script or click a button and receive a finished document moments later. This consistency enhances your brand image and reduces the risk of errors that could delay payments or cause legal issues.</p>
+<p>By partnering with Automations by Meir for document generation, you get more than templates—you gain a scalable system that adapts as your catalog of documents grows. New templates can be added with minimal effort, and integration with other automations means documents can kick off downstream actions like billing, notifications, or record updates. Let us handle the paperwork so your team can focus on delivering value.</p>
 </body>
 </html>

--- a/dist/services/process-automation.html
+++ b/dist/services/process-automation.html
@@ -3,14 +3,22 @@
 <head>
 <meta charset="UTF-8">
 <title>Process Automation | Automations by Meir</title>
+    <link rel="icon" href="/profile.jpeg" type="image/jpeg">
 <style>
  body { font-family: 'IBM Plex Sans', sans-serif; background:#0a0a0a; color:#e0e0e0; padding:2rem; }
  a { color:#00e676; }
+ p { margin-bottom:1rem; }
 </style>
 </head>
 <body>
 <a href="../index.html">&larr; Back to Home</a>
 <h1>Process Automation</h1>
-<p>Streamline workflows with custom automation for emails, reports, data processing, and complex business operations.</p>
+<p>Every organization has repetitive tasks that quietly consume hours of employee time. Process automation replaces these manual steps with reliable, rule-based workflows that run in the background. From onboarding new hires to reconciling financial records, automation ensures that procedures are followed consistently and that important steps are never overlooked. Our solutions are designed to be flexible so they can evolve as your business changes.</p>
+<p>The journey begins with a detailed process mapping exercise. We collaborate with stakeholders to document each step, decision point, and data dependency. This blueprint helps us identify redundancies and opportunities for optimization before any code is written. Often, just visualizing a process reveals shortcuts or bottlenecks that can be eliminated, reducing the overall complexity of the workflow.</p>
+<p>Once the process is understood, we translate it into an automated pipeline using tools such as Google Apps Script, Firebase, or third-party APIs. Triggers can respond to events like form submissions, calendar updates, or incoming emails. Each trigger invokes scripts that validate inputs, perform calculations, and interact with databases or external services. By chaining these modules together, we build end-to-end solutions that execute with minimal supervision.</p>
+<p>Human oversight remains important, which is why we incorporate checkpoints and approval stages where necessary. For instance, a generated report might be emailed to a manager for sign-off before it is distributed to clients. Interactive dashboards allow staff to monitor the status of running workflows, review logs, and intervene if unusual conditions are detected. Transparency builds trust and makes it easy to refine the automation over time.</p>
+<p>Error handling is a first-class concern. Instead of failing silently, our workflows capture detailed diagnostics and notify the appropriate team members. Retry mechanisms and fallback paths keep the system resilient even when external services experience outages. Because all steps are logged, compliance audits become straightforward and incidents can be traced to their root cause quickly.</p>
+<p>Process automation also delivers measurable business value. It shortens cycle times, reduces operational costs, and frees employees to focus on strategic initiatives. Clients benefit from faster response times and more predictable service. As new regulations or market conditions emerge, automated workflows can be adjusted with a few lines of code rather than retraining an entire department.</p>
+<p>Ultimately, our goal is to create automations that feel like an extension of your team. They handle the heavy lifting while people concentrate on creativity and problem solving. Automations by Meir brings together technical expertise and a deep understanding of business processes to design workflows that are robust, maintainable, and aligned with your strategic objectives.</p>
 </body>
 </html>

--- a/dist/services/web-development.html
+++ b/dist/services/web-development.html
@@ -3,14 +3,22 @@
 <head>
 <meta charset="UTF-8">
 <title>Web Development | Automations by Meir</title>
+    <link rel="icon" href="/profile.jpeg" type="image/jpeg">
 <style>
  body { font-family: 'IBM Plex Sans', sans-serif; background:#0a0a0a; color:#e0e0e0; padding:2rem; }
  a { color:#00e676; }
+ p { margin-bottom:1rem; }
 </style>
 </head>
 <body>
 <a href="../index.html">&larr; Back to Home</a>
 <h1>Web Development</h1>
-<p>Full-stack web applications with modern interfaces and robust backend automation.</p>
+<p>A modern web presence requires more than a static site—it demands fast performance, intuitive design, and seamless integration with the services that power your business. Our web development offering spans the full stack, from polished front-end experiences to robust backend APIs. Whether you need a marketing landing page or a complex application with user authentication and real-time updates, we deliver solutions that are maintainable and tailored to your objectives.</p>
+<p>We employ contemporary frameworks such as React, Vue, or Svelte on the front end, enabling rich interfaces that feel responsive and engaging. Components are built with reusability in mind, allowing new pages or features to be added quickly. Accessibility standards guide our design choices so that users with diverse needs can navigate your site without friction. Animations and transitions are used sparingly to enhance, not distract from, the primary content.</p>
+<p>On the server side, we craft APIs and business logic using Node.js, Python, or other languages best suited to the task. Data is stored in scalable databases and accessed through well-defined endpoints. Authentication and authorization are handled with industry-standard practices, giving you confidence that user information is protected. For projects that require real-time collaboration or notifications, we integrate WebSocket or server-sent event architectures that keep clients in sync.</p>
+<p>DevOps is baked into our process from day one. Continuous integration pipelines run automated tests and linting to ensure code quality. Deployments can target serverless platforms, container clusters, or traditional virtual machines depending on your infrastructure preferences. Monitoring and logging provide visibility into performance and errors, allowing us to address issues before users notice them.</p>
+<p>Content management is often a critical requirement. We work with headless CMS solutions or build custom administrative panels so non-technical staff can update copy, images, or product catalogs without developer involvement. When needed, multilingual support and localization features make it easy to reach a global audience while maintaining consistent branding.</p>
+<p>Our web projects frequently intersect with automation. Forms can feed into backend workflows, data from external APIs can populate dashboards, and user actions can trigger personalized communications. This fusion of web development and automation ensures that your site is not just a brochure but a living system that streamlines operations and improves customer engagement.</p>
+<p>Choosing Automations by Meir means partnering with a team that values transparency and collaboration. We provide clear timelines, maintain open communication channels, and deliver detailed documentation so your internal team understands how everything fits together. The result is a web application that looks great, performs reliably, and evolves gracefully as your business grows.</p>
 </body>
 </html>

--- a/dist/showcase-job-post-pro.html
+++ b/dist/showcase-job-post-pro.html
@@ -12,6 +12,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Job Post Pro - Complete System Showcase</title>
+    <link rel="icon" href="/profile.jpeg" type="image/jpeg">
     <style>
         @import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@200;300;400;500;600;700&display=swap');
         :root {

--- a/dist/showcase1.html
+++ b/dist/showcase1.html
@@ -13,6 +13,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Crypto Wallet Tracker - Automated Portfolio Management System</title>
+    <link rel="icon" href="/profile.jpeg" type="image/jpeg">
     <style>
         @import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@200;400;600;700&display=swap');
         :root {

--- a/dist/showcase2.html
+++ b/dist/showcase2.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Business Analytics System - Enterprise Automation Showcase</title>
+    <link rel="icon" href="/profile.jpeg" type="image/jpeg">
     <style>
         @import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@200;300;400;500;600;700&display=swap');
         @import url('https://fonts.googleapis.com/css2?family=Macan:wght@300;400;500;600;700;800;900&display=swap');

--- a/dist/why-automation-he.html
+++ b/dist/why-automation-he.html
@@ -4,9 +4,11 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>למה העסק שלכם צריך אוטומציה</title>
+    <link rel="icon" href="/profile.jpeg" type="image/jpeg">
     <meta name="description" content="כיצד אוטומציה משפרת יעילות וצמיחה" />
     <link rel="canonical" href="https://automationbymeir.web.app/why-automation-he.html" />
     <style>
+        @import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@200;400;600;700&display=swap');
         @import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Sans+Hebrew:wght@200;400;600;700&display=swap');
         :root {
             --primary: #00e676;
@@ -27,8 +29,23 @@
         h1 { font-weight: 200; font-family: 'IBM Plex Sans Hebrew', sans-serif; }
         nav { position: fixed; top:0; width:100%; background:rgba(10, 10, 10, 0.8); backdrop-filter:blur(10px); z-index:1000; padding:1rem 0; border-bottom:1px solid rgba(51, 51, 51, 0.5); }
         .nav-container { max-width:1200px; margin:0 auto; padding:0 2rem; display:flex; justify-content:space-between; align-items:center; }
-        .logo { font-size:1.25rem; font-weight:600; color:var(--light); text-decoration:none; display:flex; align-items:center; gap:.75rem; font-family: 'IBM Plex Sans Hebrew', sans-serif; }
+        .logo {
+            font-size:1.25rem;
+            font-weight:600;
+            color:var(--light);
+            text-decoration:none;
+            display:flex;
+            align-items:center;
+            gap:.75rem;
+            font-family: 'IBM Plex Sans', 'IBM Plex Sans Hebrew', sans-serif;
+            direction:ltr;
+        }
         .logo svg { width:40px; height:40px; }
+        .logo .by-meir {
+            color:var(--text-secondary);
+            font-weight:400;
+            font-size:0.8em;
+        }
         .nav-toggle { display:none; }
         .nav-links { display:flex; gap:2rem; list-style:none; }
         .nav-links li { position:relative; }
@@ -68,7 +85,7 @@
                     <path d="M16 14L14 20" stroke="#ffc107" stroke-width="2" stroke-linecap="round"/>
                 </svg>
                 Automations
-                <span style="color: var(--text-secondary); font-weight: 400;">BY MEIR</span>
+                <span class="by-meir">by Meir</span>
             </a>
         </div>
     </nav>

--- a/dist/why-automation.html
+++ b/dist/why-automation.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Why Your Business Needs Automation</title>
+    <link rel="icon" href="/profile.jpeg" type="image/jpeg">
     <meta name="description" content="Learn how automation streamlines operations and boosts growth with real-world examples." />
     <link rel="canonical" href="https://automationbymeir.web.app/why-automation.html" />
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>

--- a/public/about-me-he.html
+++ b/public/about-me-he.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>אודות מאיר - מומחה אוטומציה</title>
+    <link rel="icon" href="/profile.jpeg" type="image/jpeg">
     <meta name="description" content="קראו עוד על מאיר, מומחה אוטומציה המשלב בינה מלאכותית בתהליכי עבודה חכמים." />
     <link rel="canonical" href="https://automationbymeir.web.app/about-me-he.html" />
     <style>

--- a/public/about-me.html
+++ b/public/about-me.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>About Meir - Automation Specialist</title>
+    <link rel="icon" href="/profile.jpeg" type="image/jpeg">
     <meta name="description" content="Learn more about Meir, an automation specialist leveraging AI to build scalable systems." />
     <link rel="canonical" href="https://automationbymeir.web.app/about-me.html" />
     <style>

--- a/public/automation-playground.html
+++ b/public/automation-playground.html
@@ -13,6 +13,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Automation Puzzle - Build Your Perfect Workflow</title>
+    <link rel="icon" href="/profile.jpeg" type="image/jpeg">
     <style>
         @import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@200;400;600;700&display=swap');
 

--- a/public/index-he.html
+++ b/public/index-he.html
@@ -13,6 +13,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Automation by Meir - הפכו את העסק שלכם לאוטומטי וחכם</title>
+    <link rel="icon" href="/profile.jpeg" type="image/jpeg">
     <meta name="description" content="פתרונות אוטומציה מותאמים אישית לעסק שלכם" />
     <link rel="canonical" href="https://automationbymeir.web.app/index-he.html" />
     <style>
@@ -281,12 +282,12 @@
             <div class="platforms">
                 <h3 class="platforms-title">המערכות שאיתן אנחנו בונים אוטומציות</h3>
                 <div class="platform-logos">
-                    <img src="logos/googleappsscript.svg" alt="Google Apps Script">
-                    <img src="logos/firebase.svg" alt="Firebase">
-                    <img src="logos/openai.svg" alt="OpenAI">
-                    <img src="logos/claude.svg" alt="Claude">
-                    <img src="logos/googlegemini.svg" alt="Gemini">
-                    <img src="logos/grok.svg" alt="Grok">
+                    <img src="logos/googleappsscript.svg" alt="Google Apps Script" title="Extend Google Workspace with custom scripts">
+                    <img src="logos/firebase.svg" alt="Firebase" title="Backend services and hosting">
+                    <img src="logos/openai.svg" alt="OpenAI" title="Advanced language model APIs">
+                    <img src="logos/claude.svg" alt="Claude" title="Anthropic's powerful AI assistant">
+                    <img src="logos/googlegemini.svg" alt="Gemini" title="Google's multimodal AI platform">
+                    <img src="logos/grok.svg" alt="Grok" title="Real-time AI from xAI">
                 </div>
             </div>
             <div class="services-grid">

--- a/public/index.html
+++ b/public/index.html
@@ -12,6 +12,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Automations by Meir - Transform Your Business with Intelligent Automation</title>
+    <link rel="icon" href="/profile.jpeg" type="image/jpeg">
     <meta name="description" content="Custom Google Apps Script & Firebase Solutions That Scale. Streamline workflows with intelligent automation." />
     <link rel="canonical" href="https://automationbymeir.web.app/" />
     <style>
@@ -358,7 +359,6 @@
         .platform-logos img {
             height: 40px;
             filter: none;
-            cursor: help;
         }
 
         .linkedin-logo {

--- a/public/payment.html
+++ b/public/payment.html
@@ -13,9 +13,9 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Secure Payment - Automation by Meir</title>
+    <link rel="icon" href="/profile.jpeg" type="image/jpeg">
     <meta name="description" content="Complete your payment securely using PayPal." />
     <link rel="canonical" href="https://automationbymeir.web.app/payment.html" />
-    <link rel="icon" type="image/x-icon" href="/favicon.ico">
     <link rel="stylesheet" type="text/css" href="https://www.paypalobjects.com/webstatic/en_US/developer/docs/css/cardfields.css" />
     <style>
         /* Your existing CSS - No changes made */

--- a/public/services/ai-powered-systems.html
+++ b/public/services/ai-powered-systems.html
@@ -3,6 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <title>AI-Powered Systems | Automations by Meir</title>
+    <link rel="icon" href="/profile.jpeg" type="image/jpeg">
 <style>
  body { font-family: 'IBM Plex Sans', sans-serif; background:#0a0a0a; color:#e0e0e0; padding:2rem; }
  a { color:#00e676; }

--- a/public/services/api-integration.html
+++ b/public/services/api-integration.html
@@ -3,6 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <title>API Integration | Automations by Meir</title>
+    <link rel="icon" href="/profile.jpeg" type="image/jpeg">
 <style>
  body { font-family: 'IBM Plex Sans', sans-serif; background:#0a0a0a; color:#e0e0e0; padding:2rem; }
  a { color:#00e676; }

--- a/public/services/data-dashboards.html
+++ b/public/services/data-dashboards.html
@@ -3,6 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <title>Data Dashboards | Automations by Meir</title>
+    <link rel="icon" href="/profile.jpeg" type="image/jpeg">
 <style>
  body { font-family: 'IBM Plex Sans', sans-serif; background:#0a0a0a; color:#e0e0e0; padding:2rem; }
  a { color:#00e676; }

--- a/public/services/document-generation.html
+++ b/public/services/document-generation.html
@@ -3,6 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <title>Document Generation | Automations by Meir</title>
+    <link rel="icon" href="/profile.jpeg" type="image/jpeg">
 <style>
  body { font-family: 'IBM Plex Sans', sans-serif; background:#0a0a0a; color:#e0e0e0; padding:2rem; }
  a { color:#00e676; }

--- a/public/services/process-automation.html
+++ b/public/services/process-automation.html
@@ -3,6 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <title>Process Automation | Automations by Meir</title>
+    <link rel="icon" href="/profile.jpeg" type="image/jpeg">
 <style>
  body { font-family: 'IBM Plex Sans', sans-serif; background:#0a0a0a; color:#e0e0e0; padding:2rem; }
  a { color:#00e676; }

--- a/public/services/web-development.html
+++ b/public/services/web-development.html
@@ -3,6 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <title>Web Development | Automations by Meir</title>
+    <link rel="icon" href="/profile.jpeg" type="image/jpeg">
 <style>
  body { font-family: 'IBM Plex Sans', sans-serif; background:#0a0a0a; color:#e0e0e0; padding:2rem; }
  a { color:#00e676; }

--- a/public/showcase-job-post-pro.html
+++ b/public/showcase-job-post-pro.html
@@ -12,6 +12,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Job Post Pro - Complete System Showcase</title>
+    <link rel="icon" href="/profile.jpeg" type="image/jpeg">
     <style>
         @import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@200;300;400;500;600;700&display=swap');
         :root {

--- a/public/showcase1.html
+++ b/public/showcase1.html
@@ -13,6 +13,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Crypto Wallet Tracker - Automated Portfolio Management System</title>
+    <link rel="icon" href="/profile.jpeg" type="image/jpeg">
     <style>
         @import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@200;400;600;700&display=swap');
         :root {

--- a/public/showcase2.html
+++ b/public/showcase2.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Business Analytics System - Enterprise Automation Showcase</title>
+    <link rel="icon" href="/profile.jpeg" type="image/jpeg">
     <style>
         @import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@200;300;400;500;600;700&display=swap');
         @import url('https://fonts.googleapis.com/css2?family=Macan:wght@300;400;500;600;700;800;900&display=swap');

--- a/public/why-automation-he.html
+++ b/public/why-automation-he.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>למה העסק שלכם צריך אוטומציה</title>
+    <link rel="icon" href="/profile.jpeg" type="image/jpeg">
     <meta name="description" content="כיצד אוטומציה משפרת יעילות וצמיחה" />
     <link rel="canonical" href="https://automationbymeir.web.app/why-automation-he.html" />
     <style>

--- a/public/why-automation.html
+++ b/public/why-automation.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Why Your Business Needs Automation</title>
+    <link rel="icon" href="/profile.jpeg" type="image/jpeg">
     <meta name="description" content="Learn how automation streamlines operations and boosts growth with real-world examples." />
     <link rel="canonical" href="https://automationbymeir.web.app/why-automation.html" />
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>


### PR DESCRIPTION
## Summary
- remove `cursor: help` so platform icon tooltips display normally
- add descriptive titles for platform icons in the Hebrew index
- link to existing profile image for site-wide favicon, avoiding binary icon files

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build -- --outDir temp_build`


------
https://chatgpt.com/codex/tasks/task_b_689769c5d7c8833390fc29a5010dda51