### PR TITLE
feat: unify navigation with showcase dropdown

### DIFF
--- a/public/about-me-he.html
+++ b/public/about-me-he.html
@@ -38,23 +38,127 @@
         .content { padding:8rem 2rem 4rem; max-width:800px; margin:0 auto; line-height:1.8; }
         .content h1 { font-weight:200; margin-bottom:2rem; text-align:center; }
         .content p { margin-bottom:1.5rem; }
+        #header {
+            position: fixed;
+            width: 100%;
+            z-index: 100;
+            padding: 40px;
+            padding-top: 40px;
+            display: flex;
+            justify-content: space-between;
+            box-sizing: border-box;
+            align-items: flex-start;
+            top: 0;
+            left: 0;
+            height: 0;
+        }
+        #header img{
+            height:40px; width:auto;
+            backdrop-filter: blur(20px);
+            padding: 8px 8px;
+            border-radius: 8px;
+        }
+        nav {
+            display:flex;
+            flex-direction:row;
+            align-items:flex-start;
+            padding:24px;
+            gap:40px;
+            right:32px;
+            top:32px;
+            background:rgba(13,13,14,0.6);
+            backdrop-filter:blur(16px);
+            border-radius:8px;
+            z-index:100;
+            width:25%;
+            min-width:min-content;
+            flex-wrap:wrap;
+            align-content:flex-start;
+            justify-content:flex-start;
+            box-sizing:border-box;
+        }
+        nav ul{
+            list-style:none;
+            padding:0;
+            margin:0;
+            display:flex;
+            flex-direction:column;
+            gap:8px;
+            width:40%;
+            flex-grow:1;
+        }
+        a{
+            color:white;
+            text-decoration:none;
+        }
+        nav a{
+            font-size:20px;
+            position:relative;
+            display:inline-block;
+            font-weight:300;
+            white-space:nowrap;
+        }
+        nav a:after{
+            content:'';
+            display:block;
+            width:100%;
+            height:1px;
+            background:#fff;
+            transform:scaleX(0);
+            transition:transform 0.2s ease-in-out;
+            transform-origin:100% 0 ;
+        }
+        nav a:hover:after{
+            transform:scaleX(1);
+            transform-origin:0 0 ;
+        }
+        nav ul li { position: relative; }
+        nav ul li .dropdown-menu {
+            display:none;
+            position:absolute;
+            top:100%;
+            left:0;
+            background:rgba(13,13,14,0.9);
+            border-radius:8px;
+            padding:8px 0;
+            list-style:none;
+            margin:0;
+            min-width:220px;
+        }
+        nav ul li:hover .dropdown-menu { display:block; }
+        nav ul li .dropdown-menu a {
+            padding:8px 16px;
+            display:block;
+            font-size:16px;
+            white-space:nowrap;
+        }
+        nav ul li .dropdown-menu a:hover { background:#333333; }
     </style>
 </head>
 <body>
-    <nav>
-        <div class="nav-container">
-            <a href="index-he.html" class="logo" dir="ltr">
-                <img src="ma_logo.svg" alt="Automations by Meir"/>
-                Automations <span class="by-meir">by Meir</span>
-            </a>
-            <ul class="nav-links">
-                <li><a href="index-he.html#services">שירותים</a></li>
-                <li><a href="index-he.html#projects">פרויקטים</a></li>
-                <li><a href="index-he.html#about">אודות</a></li>
-                <li><a href="index-he.html#contact">צור קשר</a></li>
+    <div id="header">
+      <a href="index-he.html"><img src="ma_logo.svg" alt="Automations by Meir" /></a>
+      <nav>
+        <ul>
+          <li><a href="index-he.html#services">שירותים</a></li>
+          <li><a href="index-he.html#projects">פרויקטים</a></li>
+          <li class="dropdown"><a href="#">הדגמות</a>
+            <ul class="dropdown-menu">
+              <li><a href="showcase1.html">Crypto Wallet Tracker</a></li>
+              <li><a href="showcase2.html">Business Analytics System</a></li>
+              <li><a href="showcase-job-post-pro.html">Job Post Pro</a></li>
             </ul>
-        </div>
-    </nav>
+          </li>
+          <li><a href="why-automation-he.html">למה אוטומציה</a></li>
+          <li><a href="index-he.html#contact">צור קשר</a></li>
+        </ul>
+        <ul>
+          <li><a href="automation-playground.html">נסו בעצמכם</a></li>
+          <li><a href="payment.html">תשלומים</a></li>
+          <li><a href="index.html">EN</a></li>
+        </ul>
+      </nav>
+    </div>
     <section class="content">
         <h1>אודות מאיר</h1>
         <p>אני מומחה אוטומציה עם יותר מ-8 שנות ניסיון בתחומי הפיננסים והטכנולוגיה. באמצעות שילוב בינה מלאכותית בתהליכי עבודה, אני מסייע לעסקים לייעל תהליכים ולהגביר את היעילות.</p>

--- a/public/about-me.html
+++ b/public/about-me.html
@@ -38,23 +38,126 @@
         .content { padding:8rem 2rem 4rem; max-width:800px; margin:0 auto; line-height:1.8; }
         .content h1 { font-weight:200; margin-bottom:2rem; text-align:center; }
         .content p { margin-bottom:1.5rem; }
+        #header {
+            position: fixed;
+            width: 100%;
+            z-index: 100;
+            padding: 40px;
+            padding-top: 40px;
+            display: flex;
+            justify-content: space-between;
+            box-sizing: border-box;
+            align-items: flex-start;
+            top: 0;
+            left: 0;
+            height: 0;
+        }
+        #header img{
+            height:40px; width:auto;
+            backdrop-filter: blur(20px);
+            padding: 8px 8px;
+            border-radius: 8px;
+        }
+        nav {
+            display:flex;
+            flex-direction:row;
+            align-items:flex-start;
+            padding:24px;
+            gap:40px;
+            right:32px;
+            top:32px;
+            background:rgba(13,13,14,0.6);
+            backdrop-filter:blur(16px);
+            border-radius:8px;
+            z-index:100;
+            width:25%;
+            min-width:min-content;
+            flex-wrap:wrap;
+            align-content:flex-start;
+            justify-content:flex-start;
+            box-sizing:border-box;
+        }
+        nav ul{
+            list-style:none;
+            padding:0;
+            margin:0;
+            display:flex;
+            flex-direction:column;
+            gap:8px;
+            width:40%;
+            flex-grow:1;
+        }
+        a{
+            color:white;
+            text-decoration:none;
+        }
+        nav a{
+            font-size:20px;
+            position:relative;
+            display:inline-block;
+            font-weight:300;
+            white-space:nowrap;
+        }
+        nav a:after{
+            content:'';
+            display:block;
+            width:100%;
+            height:1px;
+            background:#fff;
+            transform:scaleX(0);
+            transition:transform 0.2s ease-in-out;
+            transform-origin:100% 0 ;
+        }
+        nav a:hover:after{
+            transform:scaleX(1);
+            transform-origin:0 0 ;
+        }
+        nav ul li { position: relative; }
+        nav ul li .dropdown-menu {
+            display:none;
+            position:absolute;
+            top:100%;
+            left:0;
+            background:rgba(13,13,14,0.9);
+            border-radius:8px;
+            padding:8px 0;
+            list-style:none;
+            margin:0;
+            min-width:220px;
+        }
+        nav ul li:hover .dropdown-menu { display:block; }
+        nav ul li .dropdown-menu a {
+            padding:8px 16px;
+            display:block;
+            font-size:16px;
+            white-space:nowrap;
+        }
+        nav ul li .dropdown-menu a:hover { background:#333333; }
     </style>
 </head>
 <body>
-    <nav>
-        <div class="nav-container">
-            <a href="index.html" class="logo">
-                <img src="ma_logo.svg" alt="Automations by Meir"/>
-                Automations <span class="by-meir">by Meir</span>
-            </a>
-            <ul class="nav-links">
-                <li><a href="index.html#services">Services</a></li>
-                <li><a href="index.html#projects">Projects</a></li>
-                <li><a href="index.html#about">About</a></li>
-                <li><a href="index.html#contact">Contact</a></li>
+    <div id="header">
+      <a href="index.html"><img src="ma_logo.svg" alt="Automations by Meir" /></a>
+      <nav>
+        <ul>
+          <li><a href="index.html#services">Services</a></li>
+          <li><a href="index.html#projects">Projects</a></li>
+          <li class="dropdown"><a href="#">Showcases</a>
+            <ul class="dropdown-menu">
+              <li><a href="showcase1.html">Crypto Wallet Tracker</a></li>
+              <li><a href="showcase2.html">Business Analytics System</a></li>
+              <li><a href="showcase-job-post-pro.html">Job Post Pro</a></li>
             </ul>
-        </div>
-    </nav>
+          </li>
+          <li><a href="why-automation.html">Why Automate</a></li>
+          <li><a href="index.html#contact">Contact Us</a></li>
+        </ul>
+        <ul>
+          <li><a href="automation-playground.html">Try live</a></li>
+          <li><a href="payment.html">Payments</a></li>
+        </ul>
+      </nav>
+    </div>
     <section class="content">
         <h1>About Meir</h1>
         <p>An automation specialist with 8+ years of experience in finance and technology, I streamline workflows and enhance efficiency. I develop and implement automation solutions that leverage AI to simplify processes, reduce manual effort, and drive productivity.</p>

--- a/public/automation-playground.html
+++ b/public/automation-playground.html
@@ -672,6 +672,101 @@
                 justify-content: center;
             }
         }
+        #header {
+            position: fixed;
+            width: 100%;
+            z-index: 100;
+            padding: 40px;
+            padding-top: 40px;
+            display: flex;
+            justify-content: space-between;
+            box-sizing: border-box;
+            align-items: flex-start;
+            top: 0;
+            left: 0;
+            height: 0;
+        }
+        #header img{
+            height:40px; width:auto;
+            backdrop-filter: blur(20px);
+            padding: 8px 8px;
+            border-radius: 8px;
+        }
+        nav {
+            display:flex;
+            flex-direction:row;
+            align-items:flex-start;
+            padding:24px;
+            gap:40px;
+            right:32px;
+            top:32px;
+            background:rgba(13,13,14,0.6);
+            backdrop-filter:blur(16px);
+            border-radius:8px;
+            z-index:100;
+            width:25%;
+            min-width:min-content;
+            flex-wrap:wrap;
+            align-content:flex-start;
+            justify-content:flex-start;
+            box-sizing:border-box;
+        }
+        nav ul{
+            list-style:none;
+            padding:0;
+            margin:0;
+            display:flex;
+            flex-direction:column;
+            gap:8px;
+            width:40%;
+            flex-grow:1;
+        }
+        a{
+            color:white;
+            text-decoration:none;
+        }
+        nav a{
+            font-size:20px;
+            position:relative;
+            display:inline-block;
+            font-weight:300;
+            white-space:nowrap;
+        }
+        nav a:after{
+            content:'';
+            display:block;
+            width:100%;
+            height:1px;
+            background:#fff;
+            transform:scaleX(0);
+            transition:transform 0.2s ease-in-out;
+            transform-origin:100% 0 ;
+        }
+        nav a:hover:after{
+            transform:scaleX(1);
+            transform-origin:0 0 ;
+        }
+        nav ul li { position: relative; }
+        nav ul li .dropdown-menu {
+            display:none;
+            position:absolute;
+            top:100%;
+            left:0;
+            background:rgba(13,13,14,0.9);
+            border-radius:8px;
+            padding:8px 0;
+            list-style:none;
+            margin:0;
+            min-width:220px;
+        }
+        nav ul li:hover .dropdown-menu { display:block; }
+        nav ul li .dropdown-menu a {
+            padding:8px 16px;
+            display:block;
+            font-size:16px;
+            white-space:nowrap;
+        }
+        nav ul li .dropdown-menu a:hover { background:#333333; }
     </style>
 </head>
 <body>
@@ -687,30 +782,29 @@
         </p>
         <button onclick="document.getElementById('guide').style.display='none'">Got it!</button>
     </div>
-    <nav id="navbar">
-        <div class="nav-container">
-            <a href="index.html" class="logo">
-                <img src="ma_logo.svg" alt="Automations by Meir"/>
-                Automations <span class="by-meir">by Meir</span>
-            </a>
-            <button class="nav-toggle" id="navToggle">☰</button>
-            <ul class="nav-links">
-                <li><a href="index.html#services">Services</a></li>
-                <li><a href="index.html#projects">Projects</a></li>
-                <li><a href="automation-playground.html" class="playground-link">Try It Live</a></li>
-                <li class="submenu"><a href="#">Showcases</a>
-                    <ul class="dropdown">
-                        <li><a href="showcase1.html">Crypto Wallet Tracker</a></li>
-                        <li><a href="showcase2.html">Enterprise Analytics Dashboard</a></li>
-                    </ul>
-                </li>
-                <li><a href="why-automation.html">Why Automate</a></li>
-                <li><a href="payment.html">Payments</a></li>
-                <li><a href="index.html#contact">Contact</a></li>
-                <li><a href="index-he.html">עברית</a></li>
+    <div id="header">
+      <a href="index.html"><img src="ma_logo.svg" alt="Automations by Meir" /></a>
+      <nav>
+        <ul>
+          <li><a href="index.html#services">Services</a></li>
+          <li><a href="index.html#projects">Projects</a></li>
+          <li class="dropdown"><a href="#">Showcases</a>
+            <ul class="dropdown-menu">
+              <li><a href="showcase1.html">Crypto Wallet Tracker</a></li>
+              <li><a href="showcase2.html">Business Analytics System</a></li>
+              <li><a href="showcase-job-post-pro.html">Job Post Pro</a></li>
             </ul>
-        </div>
-    </nav>
+          </li>
+          <li><a href="why-automation.html">Why Automate</a></li>
+          <li><a href="index.html#contact">Contact Us</a></li>
+        </ul>
+        <ul>
+          <li><a href="automation-playground.html">Try live</a></li>
+          <li><a href="payment.html">Payments</a></li>
+          <li><a href="index-he.html">עברית</a></li>
+        </ul>
+      </nav>
+    </div>
     <div class="bg-grid"></div>
     
     <!-- Floating Particles -->
@@ -1562,24 +1656,6 @@
         // Initialize on load
         createParticles();
     </script>
-    <script>
-        const navToggle = document.getElementById('navToggle');
-        const navLinks = document.querySelector('.nav-links');
-        const submenu = document.querySelector('.submenu');
-        const submenuLink = document.querySelector('.submenu > a');
-        const dropdown = document.querySelector('.submenu .dropdown');
-        navToggle.addEventListener('click', () => {
-            navLinks.classList.toggle('show');
-        });
-        submenuLink.addEventListener('click', (e) => {
-            e.preventDefault();
-            dropdown.classList.toggle('show');
-        });
-        document.addEventListener('click', (e) => {
-            if (!submenu.contains(e.target)) {
-                dropdown.classList.remove('show');
-            }
-        });
-    </script>
+    
 </body>
 </html>

--- a/public/index-he.html
+++ b/public/index-he.html
@@ -220,8 +220,103 @@
             }
             .hero h1 { font-size: 3rem; }
             .services-grid, .projects-grid, .stats-grid { grid-template-columns: 1fr; }
-            .about-header { flex-direction: column; text-align: center; }
+        .about-header { flex-direction: column; text-align: center; }
         }
+        #header {
+            position: fixed;
+            width: 100%;
+            z-index: 100;
+            padding: 40px;
+            padding-top: 40px;
+            display: flex;
+            justify-content: space-between;
+            box-sizing: border-box;
+            align-items: flex-start;
+            top: 0;
+            left: 0;
+            height: 0;
+        }
+        #header img{
+            height:40px; width:auto;
+            backdrop-filter: blur(20px);
+            padding: 8px 8px;
+            border-radius: 8px;
+        }
+        nav {
+            display:flex;
+            flex-direction:row;
+            align-items:flex-start;
+            padding:24px;
+            gap:40px;
+            right:32px;
+            top:32px;
+            background:rgba(13,13,14,0.6);
+            backdrop-filter:blur(16px);
+            border-radius:8px;
+            z-index:100;
+            width:25%;
+            min-width:min-content;
+            flex-wrap:wrap;
+            align-content:flex-start;
+            justify-content:flex-start;
+            box-sizing:border-box;
+        }
+        nav ul{
+            list-style:none;
+            padding:0;
+            margin:0;
+            display:flex;
+            flex-direction:column;
+            gap:8px;
+            width:40%;
+            flex-grow:1;
+        }
+        a{
+            color:white;
+            text-decoration:none;
+        }
+        nav a{
+            font-size:20px;
+            position:relative;
+            display:inline-block;
+            font-weight:300;
+            white-space:nowrap;
+        }
+        nav a:after{
+            content:'';
+            display:block;
+            width:100%;
+            height:1px;
+            background:#fff;
+            transform:scaleX(0);
+            transition:transform 0.2s ease-in-out;
+            transform-origin:100% 0 ;
+        }
+        nav a:hover:after{
+            transform:scaleX(1);
+            transform-origin:0 0 ;
+        }
+        nav ul li { position: relative; }
+        nav ul li .dropdown-menu {
+            display:none;
+            position:absolute;
+            top:100%;
+            left:0;
+            background:rgba(13,13,14,0.9);
+            border-radius:8px;
+            padding:8px 0;
+            list-style:none;
+            margin:0;
+            min-width:220px;
+        }
+        nav ul li:hover .dropdown-menu { display:block; }
+        nav ul li .dropdown-menu a {
+            padding:8px 16px;
+            display:block;
+            font-size:16px;
+            white-space:nowrap;
+        }
+        nav ul li .dropdown-menu a:hover { background:#333333; }
     </style>
 </head>
 <body>
@@ -230,31 +325,29 @@
     height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
     <!-- End Google Tag Manager (noscript) -->
     <div class="particles" id="particles"></div>
-    <nav id="navbar">
-        <div class="nav-container">
-            <a href="#" class="logo">
-                <img src="ma_logo.svg" alt="Automations by Meir"/>
-                Automations
-                <span class="by-meir">by Meir</span>
-            </a>
-            <button class="nav-toggle" id="navToggle">&#9776;</button>
-            <ul class="nav-links">
-                <li><a href="#services">שירותים</a></li>
-                <li><a href="#projects">פרויקטים</a></li>
-                <li><a href="automation-playground.html" class="playground-link">נסו בעצמכם</a></li>
-                <li class="submenu"><a href="#">הדגמות</a>
-                    <ul class="dropdown">
-                        <li><a href="showcase1.html">Crypto Wallet Tracker</a></li>
-                        <li><a href="showcase2.html">Enterprise Analytics Dashboard</a></li>
-                    </ul>
-                </li>
-                <li><a href="why-automation-he.html">למה אוטומציה</a></li>
-                <li><a href="payment.html">תשלומים</a></li>
-                <li><a href="#contact">צור קשר</a></li>
-                <li><a href="index.html">EN</a></li>
+    <div id="header">
+      <a href="index-he.html"><img src="ma_logo.svg" alt="Automations by Meir" /></a>
+      <nav>
+        <ul>
+          <li><a href="index-he.html#services">שירותים</a></li>
+          <li><a href="index-he.html#projects">פרויקטים</a></li>
+          <li class="dropdown"><a href="#">הדגמות</a>
+            <ul class="dropdown-menu">
+              <li><a href="showcase1.html">Crypto Wallet Tracker</a></li>
+              <li><a href="showcase2.html">Business Analytics System</a></li>
+              <li><a href="showcase-job-post-pro.html">Job Post Pro</a></li>
             </ul>
-        </div>
-    </nav>
+          </li>
+          <li><a href="why-automation-he.html">למה אוטומציה</a></li>
+          <li><a href="index-he.html#contact">צור קשר</a></li>
+        </ul>
+        <ul>
+          <li><a href="automation-playground.html">נסו בעצמכם</a></li>
+          <li><a href="payment.html">תשלומים</a></li>
+          <li><a href="index.html">EN</a></li>
+        </ul>
+      </nav>
+    </div>
     <section class="hero">
         <div class="wave-net"><canvas id="waveCanvas"></canvas></div>
         <div class="hero-content">
@@ -699,45 +792,6 @@
             particlesContainer.appendChild(particle);
         }
 
-        const navToggle = document.getElementById('navToggle');
-        const navLinks = document.querySelector('.nav-links');
-        const submenu = document.querySelector('.submenu');
-        const submenuLink = document.querySelector('.submenu > a');
-        const dropdown = document.querySelector('.submenu .dropdown');
-
-        navToggle.addEventListener('click', () => {
-            navLinks.classList.toggle('show');
-        });
-
-        submenuLink.addEventListener('click', (e) => {
-            e.preventDefault();
-            dropdown.classList.toggle('show');
-        });
-
-        document.addEventListener('click', (e) => {
-            if (!submenu.contains(e.target)) {
-                dropdown.classList.remove('show');
-            }
-        });
-
-        window.addEventListener('scroll', () => {
-            const navbar = document.getElementById('navbar');
-            if (window.scrollY > 50) {
-                navbar.style.background = 'rgba(32, 33, 36, 0.98)';
-            } else {
-                navbar.style.background = 'rgba(32, 33, 36, 0.9)';
-            }
-        });
-
-        document.querySelectorAll('a[href^="#"]').forEach(anchor => {
-            anchor.addEventListener('click', function (e) {
-                e.preventDefault();
-                const target = document.querySelector(this.getAttribute('href'));
-                if (target) {
-                    target.scrollIntoView({ behavior: 'smooth', block: 'start' });
-                }
-            });
-        });
     </script>
 </body>
 </html>

--- a/public/index.html
+++ b/public/index.html
@@ -121,6 +121,34 @@
       transform-origin: 0 0 ;
     }
 
+    nav ul li {
+      position: relative;
+    }
+    nav ul li .dropdown-menu {
+      display: none;
+      position: absolute;
+      top: 100%;
+      left: 0;
+      background: rgba(13, 13, 14, 0.9);
+      border-radius: 8px;
+      padding: 8px 0;
+      list-style: none;
+      margin: 0;
+      min-width: 220px;
+    }
+    nav ul li:hover .dropdown-menu {
+      display: block;
+    }
+    nav ul li .dropdown-menu a {
+      padding: 8px 16px;
+      display: block;
+      font-size: 16px;
+      white-space: nowrap;
+    }
+    nav ul li .dropdown-menu a:hover {
+      background: #333333;
+    }
+
     #hero {
       box-sizing: border-box;
       height: 90vh;
@@ -571,7 +599,13 @@
     <ul>
       <li><a href="#services">Services</a></li>
       <li><a href="#projects">Projects</a></li>
-      <li><a href="showcase1.html">Showcases</a></li>
+      <li class="dropdown"><a href="#">Showcases</a>
+        <ul class="dropdown-menu">
+          <li><a href="showcase1.html">Crypto Wallet Tracker</a></li>
+          <li><a href="showcase2.html">Business Analytics System</a></li>
+          <li><a href="showcase-job-post-pro.html">Job Post Pro</a></li>
+        </ul>
+      </li>
       <li><a href="why-automation.html">Why Automate</a></li>
       <li><a href="#contact">Contact Us</a></li>
     </ul>

--- a/public/payment.html
+++ b/public/payment.html
@@ -276,6 +276,101 @@
             .payment-container { padding: 2rem; }
             .payment-wrapper { padding: 5rem 1rem 1rem; }
         }
+        #header {
+            position: fixed;
+            width: 100%;
+            z-index: 100;
+            padding: 40px;
+            padding-top: 40px;
+            display: flex;
+            justify-content: space-between;
+            box-sizing: border-box;
+            align-items: flex-start;
+            top: 0;
+            left: 0;
+            height: 0;
+        }
+        #header img{
+            height:40px; width:auto;
+            backdrop-filter: blur(20px);
+            padding: 8px 8px;
+            border-radius: 8px;
+        }
+        nav {
+            display:flex;
+            flex-direction:row;
+            align-items:flex-start;
+            padding:24px;
+            gap:40px;
+            right:32px;
+            top:32px;
+            background:rgba(13,13,14,0.6);
+            backdrop-filter:blur(16px);
+            border-radius:8px;
+            z-index:100;
+            width:25%;
+            min-width:min-content;
+            flex-wrap:wrap;
+            align-content:flex-start;
+            justify-content:flex-start;
+            box-sizing:border-box;
+        }
+        nav ul{
+            list-style:none;
+            padding:0;
+            margin:0;
+            display:flex;
+            flex-direction:column;
+            gap:8px;
+            width:40%;
+            flex-grow:1;
+        }
+        a{
+            color:white;
+            text-decoration:none;
+        }
+        nav a{
+            font-size:20px;
+            position:relative;
+            display:inline-block;
+            font-weight:300;
+            white-space:nowrap;
+        }
+        nav a:after{
+            content:'';
+            display:block;
+            width:100%;
+            height:1px;
+            background:#fff;
+            transform:scaleX(0);
+            transition:transform 0.2s ease-in-out;
+            transform-origin:100% 0 ;
+        }
+        nav a:hover:after{
+            transform:scaleX(1);
+            transform-origin:0 0 ;
+        }
+        nav ul li { position: relative; }
+        nav ul li .dropdown-menu {
+            display:none;
+            position:absolute;
+            top:100%;
+            left:0;
+            background:rgba(13,13,14,0.9);
+            border-radius:8px;
+            padding:8px 0;
+            list-style:none;
+            margin:0;
+            min-width:220px;
+        }
+        nav ul li:hover .dropdown-menu { display:block; }
+        nav ul li .dropdown-menu a {
+            padding:8px 16px;
+            display:block;
+            font-size:16px;
+            white-space:nowrap;
+        }
+        nav ul li .dropdown-menu a:hover { background:#333333; }
     </style>
 </head>
 <body>
@@ -285,30 +380,29 @@
     <!-- End Google Tag Manager (noscript) -->
     <div class="bg-animation"></div>
     
-    <nav id="navbar">
-        <div class="nav-container">
-            <a href="index.html" class="logo">
-                <img src="ma_logo.svg" alt="Automations by Meir"/>
-                Automations <span class="by-meir">by Meir</span>
-            </a>
-            <button class="nav-toggle" id="navToggle">☰</button>
-            <ul class="nav-links">
-                <li><a href="index.html#services">Services</a></li>
-                <li><a href="index.html#projects">Projects</a></li>
-                <li><a href="automation-playground.html" class="playground-link">Try It Live</a></li>
-                <li class="submenu"><a href="#">Showcases</a>
-                    <ul class="dropdown">
-                        <li><a href="showcase1.html">Crypto Wallet Tracker</a></li>
-                        <li><a href="showcase2.html">Enterprise Analytics Dashboard</a></li>
-                    </ul>
-                </li>
-                <li><a href="why-automation.html">Why Automate</a></li>
-                <li><a href="payment.html">Payments</a></li>
-                <li><a href="index.html#contact">Contact</a></li>
-                <li><a href="index-he.html">עברית</a></li>
+    <div id="header">
+      <a href="index.html"><img src="ma_logo.svg" alt="Automations by Meir" /></a>
+      <nav>
+        <ul>
+          <li><a href="index.html#services">Services</a></li>
+          <li><a href="index.html#projects">Projects</a></li>
+          <li class="dropdown"><a href="#">Showcases</a>
+            <ul class="dropdown-menu">
+              <li><a href="showcase1.html">Crypto Wallet Tracker</a></li>
+              <li><a href="showcase2.html">Business Analytics System</a></li>
+              <li><a href="showcase-job-post-pro.html">Job Post Pro</a></li>
             </ul>
-        </div>
-    </nav>
+          </li>
+          <li><a href="why-automation.html">Why Automate</a></li>
+          <li><a href="index.html#contact">Contact Us</a></li>
+        </ul>
+        <ul>
+          <li><a href="automation-playground.html">Try live</a></li>
+          <li><a href="payment.html">Payments</a></li>
+          <li><a href="index-he.html">עברית</a></li>
+        </ul>
+      </nav>
+    </div>
 
     <div class="payment-wrapper">
         <div class="payment-container">
@@ -337,25 +431,7 @@
 
     <script src="https://www.paypal.com/sdk/js?client-id=AaSn2JSC0jwjh-bbre2EiOkOIbd-L-H7RsN-LUYb1fiQqLZGdCfDlaTn0FQrj_Dc7F28Xo0eUcicOi22&buyer-country=US&currency=USD&components=buttons&enable-funding=venmo"></script>
     <script type="module" src="/app.js"></script>
-    <script>
-        const navToggle = document.getElementById('navToggle');
-        const navLinks = document.querySelector('.nav-links');
-        const submenu = document.querySelector('.submenu');
-        const submenuLink = document.querySelector('.submenu > a');
-        const dropdown = document.querySelector('.submenu .dropdown');
-        navToggle.addEventListener('click', () => {
-            navLinks.classList.toggle('show');
-        });
-        submenuLink.addEventListener('click', (e) => {
-            e.preventDefault();
-            dropdown.classList.toggle('show');
-        });
-        document.addEventListener('click', (e) => {
-            if (!submenu.contains(e.target)) {
-                dropdown.classList.remove('show');
-            }
-        });
-    </script>
+    
 
 </body>
 </html>

--- a/public/showcase-job-post-pro.html
+++ b/public/showcase-job-post-pro.html
@@ -740,34 +740,127 @@
             from { box-shadow: 0 0 20px rgba(0, 230, 118, 0.5); }
             to { box-shadow: 0 0 30px rgba(0, 230, 118, 0.8), 0 0 40px rgba(0, 230, 118, 0.4); }
         }
+        #header {
+            position: fixed;
+            width: 100%;
+            z-index: 100;
+            padding: 40px;
+            padding-top: 40px;
+            display: flex;
+            justify-content: space-between;
+            box-sizing: border-box;
+            align-items: flex-start;
+            top: 0;
+            left: 0;
+            height: 0;
+        }
+        #header img{
+            height:40px; width:auto;
+            backdrop-filter: blur(20px);
+            padding: 8px 8px;
+            border-radius: 8px;
+        }
+        nav {
+            display:flex;
+            flex-direction:row;
+            align-items:flex-start;
+            padding:24px;
+            gap:40px;
+            right:32px;
+            top:32px;
+            background:rgba(13,13,14,0.6);
+            backdrop-filter:blur(16px);
+            border-radius:8px;
+            z-index:100;
+            width:25%;
+            min-width:min-content;
+            flex-wrap:wrap;
+            align-content:flex-start;
+            justify-content:flex-start;
+            box-sizing:border-box;
+        }
+        nav ul{
+            list-style:none;
+            padding:0;
+            margin:0;
+            display:flex;
+            flex-direction:column;
+            gap:8px;
+            width:40%;
+            flex-grow:1;
+        }
+        a{
+            color:white;
+            text-decoration:none;
+        }
+        nav a{
+            font-size:20px;
+            position:relative;
+            display:inline-block;
+            font-weight:300;
+            white-space:nowrap;
+        }
+        nav a:after{
+            content:'';
+            display:block;
+            width:100%;
+            height:1px;
+            background:#fff;
+            transform:scaleX(0);
+            transition:transform 0.2s ease-in-out;
+            transform-origin:100% 0 ;
+        }
+        nav a:hover:after{
+            transform:scaleX(1);
+            transform-origin:0 0 ;
+        }
+        nav ul li { position: relative; }
+        nav ul li .dropdown-menu {
+            display:none;
+            position:absolute;
+            top:100%;
+            left:0;
+            background:rgba(13,13,14,0.9);
+            border-radius:8px;
+            padding:8px 0;
+            list-style:none;
+            margin:0;
+            min-width:220px;
+        }
+        nav ul li:hover .dropdown-menu { display:block; }
+        nav ul li .dropdown-menu a {
+            padding:8px 16px;
+            display:block;
+            font-size:16px;
+            white-space:nowrap;
+        }
+        nav ul li .dropdown-menu a:hover { background:#333333; }
     </style>
 </head>
 <body>
-    <nav id="navbar">
-        <div class="nav-container">
-            <a href="index.html" class="logo">
-                <img src="ma_logo.svg" alt="Automations by Meir"/>
-                Automations <span class="by-meir">by Meir</span>
-            </a>
-            <button class="nav-toggle" id="navToggle">☰</button>
-            <ul class="nav-links">
-                <li><a href="index.html#services">Services</a></li>
-                <li><a href="index.html#projects">Projects</a></li>
-                <li><a href="automation-playground.html" class="playground-link">Try It Live</a></li>
-                <li class="submenu"><a href="#">Showcases</a>
-                    <ul class="dropdown">
-                        <li><a href="showcase1.html">Crypto Wallet Tracker</a></li>
-                        <li><a href="showcase2.html">Business Analytics System</a></li>
-                        <li><a href="showcase-job-post-pro.html">Job Post Pro System</a></li>
-                    </ul>
-                </li>
-                <li><a href="why-automation.html">Why Automate</a></li>
-                <li><a href="payment.html">Payments</a></li>
-                <li><a href="index.html#contact">Contact</a></li>
-                <li><a href="index-he.html">עברית</a></li>
+    <div id="header">
+      <a href="index.html"><img src="ma_logo.svg" alt="Automations by Meir" /></a>
+      <nav>
+        <ul>
+          <li><a href="index.html#services">Services</a></li>
+          <li><a href="index.html#projects">Projects</a></li>
+          <li class="dropdown"><a href="#">Showcases</a>
+            <ul class="dropdown-menu">
+              <li><a href="showcase1.html">Crypto Wallet Tracker</a></li>
+              <li><a href="showcase2.html">Business Analytics System</a></li>
+              <li><a href="showcase-job-post-pro.html">Job Post Pro</a></li>
             </ul>
-        </div>
-    </nav>
+          </li>
+          <li><a href="why-automation.html">Why Automate</a></li>
+          <li><a href="index.html#contact">Contact Us</a></li>
+        </ul>
+        <ul>
+          <li><a href="automation-playground.html">Try live</a></li>
+          <li><a href="payment.html">Payments</a></li>
+          <li><a href="index-he.html">עברית</a></li>
+        </ul>
+      </nav>
+    </div>
     <div class="showcase-container">
         <!-- Header -->
         <div class="header">
@@ -1114,24 +1207,6 @@
             observer.observe(el);
         });
     </script>
-    <script>
-        const navToggle = document.getElementById('navToggle');
-        const navLinks = document.querySelector('.nav-links');
-        const submenu = document.querySelector('.submenu');
-        const submenuLink = document.querySelector('.submenu > a');
-        const dropdown = document.querySelector('.submenu .dropdown');
-        navToggle.addEventListener('click', () => {
-            navLinks.classList.toggle('show');
-        });
-        submenuLink.addEventListener('click', (e) => {
-            e.preventDefault();
-            dropdown.classList.toggle('show');
-        });
-        document.addEventListener('click', (e) => {
-            if (!submenu.contains(e.target)) {
-                dropdown.classList.remove('show');
-            }
-        });
-    </script>
+    
 </body>
 </html>

--- a/public/showcase1.html
+++ b/public/showcase1.html
@@ -802,9 +802,127 @@
             from { box-shadow: 0 0 20px rgba(98, 126, 234, 0.5); }
             to { box-shadow: 0 0 30px rgba(98, 126, 234, 0.8), 0 0 40px rgba(247, 147, 26, 0.4); }
         }
+        #header {
+            position: fixed;
+            width: 100%;
+            z-index: 100;
+            padding: 40px;
+            padding-top: 40px;
+            display: flex;
+            justify-content: space-between;
+            box-sizing: border-box;
+            align-items: flex-start;
+            top: 0;
+            left: 0;
+            height: 0;
+        }
+        #header img{
+            height:40px; width:auto;
+            backdrop-filter: blur(20px);
+            padding: 8px 8px;
+            border-radius: 8px;
+        }
+        nav {
+            display:flex;
+            flex-direction:row;
+            align-items:flex-start;
+            padding:24px;
+            gap:40px;
+            right:32px;
+            top:32px;
+            background:rgba(13,13,14,0.6);
+            backdrop-filter:blur(16px);
+            border-radius:8px;
+            z-index:100;
+            width:25%;
+            min-width:min-content;
+            flex-wrap:wrap;
+            align-content:flex-start;
+            justify-content:flex-start;
+            box-sizing:border-box;
+        }
+        nav ul{
+            list-style:none;
+            padding:0;
+            margin:0;
+            display:flex;
+            flex-direction:column;
+            gap:8px;
+            width:40%;
+            flex-grow:1;
+        }
+        a{
+            color:white;
+            text-decoration:none;
+        }
+        nav a{
+            font-size:20px;
+            position:relative;
+            display:inline-block;
+            font-weight:300;
+            white-space:nowrap;
+        }
+        nav a:after{
+            content:'';
+            display:block;
+            width:100%;
+            height:1px;
+            background:#fff;
+            transform:scaleX(0);
+            transition:transform 0.2s ease-in-out;
+            transform-origin:100% 0 ;
+        }
+        nav a:hover:after{
+            transform:scaleX(1);
+            transform-origin:0 0 ;
+        }
+        nav ul li { position: relative; }
+        nav ul li .dropdown-menu {
+            display:none;
+            position:absolute;
+            top:100%;
+            left:0;
+            background:rgba(13,13,14,0.9);
+            border-radius:8px;
+            padding:8px 0;
+            list-style:none;
+            margin:0;
+            min-width:220px;
+        }
+        nav ul li:hover .dropdown-menu { display:block; }
+        nav ul li .dropdown-menu a {
+            padding:8px 16px;
+            display:block;
+            font-size:16px;
+            white-space:nowrap;
+        }
+        nav ul li .dropdown-menu a:hover { background:#333333; }
     </style>
 </head>
 <body>
+    <div id="header">
+      <a href="index.html"><img src="ma_logo.svg" alt="Automations by Meir" /></a>
+      <nav>
+        <ul>
+          <li><a href="index.html#services">Services</a></li>
+          <li><a href="index.html#projects">Projects</a></li>
+          <li class="dropdown"><a href="#">Showcases</a>
+            <ul class="dropdown-menu">
+              <li><a href="showcase1.html">Crypto Wallet Tracker</a></li>
+              <li><a href="showcase2.html">Business Analytics System</a></li>
+              <li><a href="showcase-job-post-pro.html">Job Post Pro</a></li>
+            </ul>
+          </li>
+          <li><a href="why-automation.html">Why Automate</a></li>
+          <li><a href="index.html#contact">Contact Us</a></li>
+        </ul>
+        <ul>
+          <li><a href="automation-playground.html">Try live</a></li>
+          <li><a href="payment.html">Payments</a></li>
+          <li><a href="index-he.html">עברית</a></li>
+        </ul>
+      </nav>
+    </div>
     <div class="showcase-container">
         <!-- Header -->
         <div class="header">

--- a/public/showcase2.html
+++ b/public/showcase2.html
@@ -889,34 +889,127 @@
             background: #404145;
             transform: translateY(-2px);
         }
+        #header {
+            position: fixed;
+            width: 100%;
+            z-index: 100;
+            padding: 40px;
+            padding-top: 40px;
+            display: flex;
+            justify-content: space-between;
+            box-sizing: border-box;
+            align-items: flex-start;
+            top: 0;
+            left: 0;
+            height: 0;
+        }
+        #header img{
+            height:40px; width:auto;
+            backdrop-filter: blur(20px);
+            padding: 8px 8px;
+            border-radius: 8px;
+        }
+        nav {
+            display:flex;
+            flex-direction:row;
+            align-items:flex-start;
+            padding:24px;
+            gap:40px;
+            right:32px;
+            top:32px;
+            background:rgba(13,13,14,0.6);
+            backdrop-filter:blur(16px);
+            border-radius:8px;
+            z-index:100;
+            width:25%;
+            min-width:min-content;
+            flex-wrap:wrap;
+            align-content:flex-start;
+            justify-content:flex-start;
+            box-sizing:border-box;
+        }
+        nav ul{
+            list-style:none;
+            padding:0;
+            margin:0;
+            display:flex;
+            flex-direction:column;
+            gap:8px;
+            width:40%;
+            flex-grow:1;
+        }
+        a{
+            color:white;
+            text-decoration:none;
+        }
+        nav a{
+            font-size:20px;
+            position:relative;
+            display:inline-block;
+            font-weight:300;
+            white-space:nowrap;
+        }
+        nav a:after{
+            content:'';
+            display:block;
+            width:100%;
+            height:1px;
+            background:#fff;
+            transform:scaleX(0);
+            transition:transform 0.2s ease-in-out;
+            transform-origin:100% 0 ;
+        }
+        nav a:hover:after{
+            transform:scaleX(1);
+            transform-origin:0 0 ;
+        }
+        nav ul li { position: relative; }
+        nav ul li .dropdown-menu {
+            display:none;
+            position:absolute;
+            top:100%;
+            left:0;
+            background:rgba(13,13,14,0.9);
+            border-radius:8px;
+            padding:8px 0;
+            list-style:none;
+            margin:0;
+            min-width:220px;
+        }
+        nav ul li:hover .dropdown-menu { display:block; }
+        nav ul li .dropdown-menu a {
+            padding:8px 16px;
+            display:block;
+            font-size:16px;
+            white-space:nowrap;
+        }
+        nav ul li .dropdown-menu a:hover { background:#333333; }
     </style>
 </head>
 <body>
-    <nav id="navbar">
-        <div class="nav-container">
-            <a href="index.html" class="logo">
-                <img src="ma_logo.svg" alt="Automations by Meir"/>
-                Automations <span class="by-meir">by Meir</span>
-            </a>
-            <button class="nav-toggle" id="navToggle">☰</button>
-            <ul class="nav-links">
-                <li><a href="index.html#services">Services</a></li>
-                <li><a href="index.html#projects">Projects</a></li>
-                <li><a href="automation-playground.html" class="playground-link">Try It Live</a></li>
-                <li class="submenu"><a href="#">Showcases</a>
-                    <ul class="dropdown">
-                        <li><a href="showcase1.html">Crypto Wallet Tracker</a></li>
-                        <li><a href="showcase2.html">Business Analytics System</a></li>
-                        <li><a href="showcase-job-post-pro.html">Job Post Pro System</a></li>
-                    </ul>
-                </li>
-                <li><a href="why-automation.html">Why Automate</a></li>
-                <li><a href="payment.html">Payments</a></li>
-                <li><a href="index.html#contact">Contact</a></li>
-                <li><a href="index-he.html">עברית</a></li>
+    <div id="header">
+      <a href="index.html"><img src="ma_logo.svg" alt="Automations by Meir" /></a>
+      <nav>
+        <ul>
+          <li><a href="index.html#services">Services</a></li>
+          <li><a href="index.html#projects">Projects</a></li>
+          <li class="dropdown"><a href="#">Showcases</a>
+            <ul class="dropdown-menu">
+              <li><a href="showcase1.html">Crypto Wallet Tracker</a></li>
+              <li><a href="showcase2.html">Business Analytics System</a></li>
+              <li><a href="showcase-job-post-pro.html">Job Post Pro</a></li>
             </ul>
-        </div>
-    </nav>
+          </li>
+          <li><a href="why-automation.html">Why Automate</a></li>
+          <li><a href="index.html#contact">Contact Us</a></li>
+        </ul>
+        <ul>
+          <li><a href="automation-playground.html">Try live</a></li>
+          <li><a href="payment.html">Payments</a></li>
+          <li><a href="index-he.html">עברית</a></li>
+        </ul>
+      </nav>
+    </div>
     <div class="showcase-container">
         <!-- Header -->
         <div class="header">
@@ -1380,24 +1473,6 @@
             this.style.cursor = 'default';
         });
     </script>
-    <script>
-        const navToggle = document.getElementById('navToggle');
-        const navLinks = document.querySelector('.nav-links');
-        const submenu = document.querySelector('.submenu');
-        const submenuLink = document.querySelector('.submenu > a');
-        const dropdown = document.querySelector('.submenu .dropdown');
-        navToggle.addEventListener('click', () => {
-            navLinks.classList.toggle('show');
-        });
-        submenuLink.addEventListener('click', (e) => {
-            e.preventDefault();
-            dropdown.classList.toggle('show');
-        });
-        document.addEventListener('click', (e) => {
-            if (!submenu.contains(e.target)) {
-                dropdown.classList.remove('show');
-            }
-        });
-    </script>
+    
 </body>
 </html>

--- a/public/why-automation-he.html
+++ b/public/why-automation-he.html
@@ -65,32 +65,127 @@
         article{max-width:800px; margin:6rem auto 2rem; padding:0 1rem; line-height:1.8;}
         article h1{font-size:2.5rem; margin-bottom:1rem;}
         article h2{margin-top:2rem; color:var(--secondary);}
+        #header {
+            position: fixed;
+            width: 100%;
+            z-index: 100;
+            padding: 40px;
+            padding-top: 40px;
+            display: flex;
+            justify-content: space-between;
+            box-sizing: border-box;
+            align-items: flex-start;
+            top: 0;
+            left: 0;
+            height: 0;
+        }
+        #header img{
+            height:40px; width:auto;
+            backdrop-filter: blur(20px);
+            padding: 8px 8px;
+            border-radius: 8px;
+        }
+        nav {
+            display:flex;
+            flex-direction:row;
+            align-items:flex-start;
+            padding:24px;
+            gap:40px;
+            right:32px;
+            top:32px;
+            background:rgba(13,13,14,0.6);
+            backdrop-filter:blur(16px);
+            border-radius:8px;
+            z-index:100;
+            width:25%;
+            min-width:min-content;
+            flex-wrap:wrap;
+            align-content:flex-start;
+            justify-content:flex-start;
+            box-sizing:border-box;
+        }
+        nav ul{
+            list-style:none;
+            padding:0;
+            margin:0;
+            display:flex;
+            flex-direction:column;
+            gap:8px;
+            width:40%;
+            flex-grow:1;
+        }
+        a{
+            color:white;
+            text-decoration:none;
+        }
+        nav a{
+            font-size:20px;
+            position:relative;
+            display:inline-block;
+            font-weight:300;
+            white-space:nowrap;
+        }
+        nav a:after{
+            content:'';
+            display:block;
+            width:100%;
+            height:1px;
+            background:#fff;
+            transform:scaleX(0);
+            transition:transform 0.2s ease-in-out;
+            transform-origin:100% 0 ;
+        }
+        nav a:hover:after{
+            transform:scaleX(1);
+            transform-origin:0 0 ;
+        }
+        nav ul li { position: relative; }
+        nav ul li .dropdown-menu {
+            display:none;
+            position:absolute;
+            top:100%;
+            left:0;
+            background:rgba(13,13,14,0.9);
+            border-radius:8px;
+            padding:8px 0;
+            list-style:none;
+            margin:0;
+            min-width:220px;
+        }
+        nav ul li:hover .dropdown-menu { display:block; }
+        nav ul li .dropdown-menu a {
+            padding:8px 16px;
+            display:block;
+            font-size:16px;
+            white-space:nowrap;
+        }
+        nav ul li .dropdown-menu a:hover { background:#333333; }
     </style>
 </head>
 <body>
-    <nav id="navbar">
-        <div class="nav-container">
-            <div class="lang-switcher">
-                <a href="index.html">EN</a>
-                <a href="#" class="active">HE</a>
-            </div>
-            <button class="nav-toggle" id="navToggle">&#9776;</button>
-            <ul class="nav-links">
-                <li><a href="#contact">צור קשר</a></li>
-                <li><a href="payment.html">תשלומים</a></li>
-                <li><a href="#about">אודות</a></li>
-                <li><a href="why-automation-he.html">למה אוטומציה?</a></li>
-                <li><a href="automation-playground.html" class="playground-link">נסו בעצמכם</a></li>
-                <li><a href="#projects">פרויקטים</a></li>
-                <li><a href="#services">שירותים</a></li>
+    <div id="header">
+      <a href="index-he.html"><img src="ma_logo.svg" alt="Automations by Meir" /></a>
+      <nav>
+        <ul>
+          <li><a href="index-he.html#services">שירותים</a></li>
+          <li><a href="index-he.html#projects">פרויקטים</a></li>
+          <li class="dropdown"><a href="#">הדגמות</a>
+            <ul class="dropdown-menu">
+              <li><a href="showcase1.html">Crypto Wallet Tracker</a></li>
+              <li><a href="showcase2.html">Business Analytics System</a></li>
+              <li><a href="showcase-job-post-pro.html">Job Post Pro</a></li>
             </ul>
-            <a href="#" class="logo">
-                <img src="ma_logo.svg" alt="Automations by Meir"/>
-                Automations
-                <span class="by-meir">by Meir</span>
-            </a>
-        </div>
-    </nav>
+          </li>
+          <li><a href="why-automation-he.html">למה אוטומציה</a></li>
+          <li><a href="index-he.html#contact">צור קשר</a></li>
+        </ul>
+        <ul>
+          <li><a href="automation-playground.html">נסו בעצמכם</a></li>
+          <li><a href="payment.html">תשלומים</a></li>
+          <li><a href="index.html">EN</a></li>
+        </ul>
+      </nav>
+    </div>
     <article>
         <h1>למה העסק שלכם צריך אוטומציה</h1>
         <p>בעולם העסקי המהיר של היום, משימות חוזרות שואבות שעות עבודה יקרות. אוטומציה מחזירה את הזמן ומאפשרת להתמקד בצמיחה.</p>
@@ -109,12 +204,6 @@
         <p>אוטומציה מעניקה יתרון תחרותי ומכינה את העסק לעתיד יעיל ורווחי יותר.</p>
     </article>
 
-    <script>
-        const navToggle = document.getElementById('navToggle');
-        const navLinks = document.querySelector('.nav-links');
-        navToggle.addEventListener('click', () => {
-            navLinks.classList.toggle('show');
-        });
-    </script>
+    
 </body>
 </html>

--- a/public/why-automation.html
+++ b/public/why-automation.html
@@ -128,34 +128,127 @@
         article h2{margin-top:2rem; color:var(--secondary);}
         .chart-container{max-width:600px; margin:2rem auto;}
         .chart-container canvas{background:var(--light); border-radius:8px; padding:1rem;}
+        #header {
+            position: fixed;
+            width: 100%;
+            z-index: 100;
+            padding: 40px;
+            padding-top: 40px;
+            display: flex;
+            justify-content: space-between;
+            box-sizing: border-box;
+            align-items: flex-start;
+            top: 0;
+            left: 0;
+            height: 0;
+        }
+        #header img{
+            height:40px; width:auto;
+            backdrop-filter: blur(20px);
+            padding: 8px 8px;
+            border-radius: 8px;
+        }
+        nav {
+            display:flex;
+            flex-direction:row;
+            align-items:flex-start;
+            padding:24px;
+            gap:40px;
+            right:32px;
+            top:32px;
+            background:rgba(13,13,14,0.6);
+            backdrop-filter:blur(16px);
+            border-radius:8px;
+            z-index:100;
+            width:25%;
+            min-width:min-content;
+            flex-wrap:wrap;
+            align-content:flex-start;
+            justify-content:flex-start;
+            box-sizing:border-box;
+        }
+        nav ul{
+            list-style:none;
+            padding:0;
+            margin:0;
+            display:flex;
+            flex-direction:column;
+            gap:8px;
+            width:40%;
+            flex-grow:1;
+        }
+        a{
+            color:white;
+            text-decoration:none;
+        }
+        nav a{
+            font-size:20px;
+            position:relative;
+            display:inline-block;
+            font-weight:300;
+            white-space:nowrap;
+        }
+        nav a:after{
+            content:'';
+            display:block;
+            width:100%;
+            height:1px;
+            background:#fff;
+            transform:scaleX(0);
+            transition:transform 0.2s ease-in-out;
+            transform-origin:100% 0 ;
+        }
+        nav a:hover:after{
+            transform:scaleX(1);
+            transform-origin:0 0 ;
+        }
+        nav ul li { position: relative; }
+        nav ul li .dropdown-menu {
+            display:none;
+            position:absolute;
+            top:100%;
+            left:0;
+            background:rgba(13,13,14,0.9);
+            border-radius:8px;
+            padding:8px 0;
+            list-style:none;
+            margin:0;
+            min-width:220px;
+        }
+        nav ul li:hover .dropdown-menu { display:block; }
+        nav ul li .dropdown-menu a {
+            padding:8px 16px;
+            display:block;
+            font-size:16px;
+            white-space:nowrap;
+        }
+        nav ul li .dropdown-menu a:hover { background:#333333; }
     </style>
 </head>
 <body>
-    <nav id="navbar">
-        <div class="nav-container">
-            <a href="index.html" class="logo">
-                <img src="ma_logo.svg" alt="Automations by Meir"/>
-                Automations <span class="by-meir">by Meir</span>
-            </a>
-            <button class="nav-toggle" id="navToggle">☰</button>
-            <ul class="nav-links">
-                <li><a href="index.html#services">Services</a></li>
-                <li><a href="index.html#projects">Projects</a></li>
-                <li><a href="automation-playground.html" class="playground-link">Try It Live</a></li>
-                <li class="submenu"><a href="#">Showcases</a>
-                    <ul class="dropdown">
-                        <li><a href="showcase1.html">Crypto Wallet Tracker</a></li>
-                        <li><a href="showcase2.html">Enterprise Analytics Dashboard</a></li>
-                    </ul>
-                </li>
-                <li><a href="index.html#about">About</a></li>
-                <li><a href="payment.html">Payments</a></li>
-                <li><a href="why-automation.html">Why Automate</a></li>
-                <li><a href="index.html#contact">Contact</a></li>
-                <li><a href="index-he.html">עברית</a></li>
+    <div id="header">
+      <a href="index.html"><img src="ma_logo.svg" alt="Automations by Meir" /></a>
+      <nav>
+        <ul>
+          <li><a href="index.html#services">Services</a></li>
+          <li><a href="index.html#projects">Projects</a></li>
+          <li class="dropdown"><a href="#">Showcases</a>
+            <ul class="dropdown-menu">
+              <li><a href="showcase1.html">Crypto Wallet Tracker</a></li>
+              <li><a href="showcase2.html">Business Analytics System</a></li>
+              <li><a href="showcase-job-post-pro.html">Job Post Pro</a></li>
             </ul>
-        </div>
-    </nav>
+          </li>
+          <li><a href="why-automation.html">Why Automate</a></li>
+          <li><a href="index.html#contact">Contact Us</a></li>
+        </ul>
+        <ul>
+          <li><a href="automation-playground.html">Try live</a></li>
+          <li><a href="payment.html">Payments</a></li>
+          <li><a href="index-he.html">עברית</a></li>
+        </ul>
+      </nav>
+    </div>
     <article>
         <h1>Why Your Business Needs Automation</h1>
         <p>In today’s fast-paced market, businesses run on countless repetitive tasks – from copying data between systems to sending routine emails – that quietly consume hours of employee time. Studies show the average knowledge worker spends nearly <strong>4 hours per day</strong> on tasks that could be automated:. That’s over <strong>100 hours every month</strong> lost to busywork. By embracing automation, companies can reclaim this time, allowing teams to focus on strategic, high-value activities that drive growth.</p>
@@ -191,24 +284,6 @@
 
 
     <script>
-        const navToggle = document.getElementById('navToggle');
-        const navLinks = document.querySelector('.nav-links');
-        const submenu = document.querySelector('.submenu');
-        const submenuLink = document.querySelector('.submenu > a');
-        const dropdown = document.querySelector('.submenu .dropdown');
-        navToggle.addEventListener('click', () => {
-            navLinks.classList.toggle('show');
-        });
-        submenuLink.addEventListener('click', (e) => {
-            e.preventDefault();
-            dropdown.classList.toggle('show');
-        });
-        document.addEventListener('click', (e) => {
-            if (!submenu.contains(e.target)) {
-                dropdown.classList.remove('show');
-            }
-        });
-
         const timeCtx = document.getElementById('timeChart').getContext('2d');
         new Chart(timeCtx, {
             type: 'bar',


### PR DESCRIPTION
## Summary
- add hover dropdown with showcase links in main navigation
- standardize header nav across all pages and remove visible 'Automation by Meir' text

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_b_68a48df014c48333af03d933cdccd56f