### PR TITLE
Fix playground navigation and remove typing option

### DIFF
--- a/dist/automation-playground.html
+++ b/dist/automation-playground.html
@@ -251,9 +251,10 @@
         /* Main Container */
         .container {
             display: flex;
-            height: 100vh;
+            height: calc(100vh - 120px);
             position: relative;
             z-index: 1;
+            margin-top: 120px;
         }
 
         /* Service Panel */
@@ -530,48 +531,7 @@
             margin-top: 0.25rem;
         }
 
-        /* Guide overlay */
-        #guide {
-            position: fixed;
-            top: 0;
-            left: 0;
-            width: 100%;
-            background: #ffffe0;
-            color: #000;
-            padding: 10px;
-            border-bottom: 1px solid #ccc;
-            z-index: 3000;
-        }
-        #guide button {
-            margin-top: 10px;
-        }
-
-        /* Chat controls */
-        #chat-controls {
-            position: fixed;
-            bottom: 20px;
-            left: 50%;
-            transform: translateX(-50%);
-            display: flex;
-            gap: 0.5rem;
-            z-index: 1100;
-        }
-        #chatInput {
-            padding: 0.5rem;
-            width: 300px;
-            border-radius: 4px;
-            border: 1px solid #444;
-            background: #2d2d30;
-            color: #fff;
-        }
-        #chatSend {
-            padding: 0.5rem 1rem;
-            background: var(--primary);
-            border: none;
-            border-radius: 4px;
-            cursor: pointer;
-            color: #000;
-        }
+        /* Chat controls removed */
 
         /* Action Buttons */
         .action-buttons {
@@ -678,14 +638,6 @@
     <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-PZ9XZMFL"
     height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
     <!-- End Google Tag Manager (noscript) -->
-    <div id="guide">
-        <h2>How to use this canvas</h2>
-        <p>
-            1. Drag service blocks onto the canvas.<br>
-            2. Type instructions in the chat below to arrange them automatically.
-        </p>
-        <button onclick="document.getElementById('guide').style.display='none'">Got it!</button>
-    </div>
     <nav id="navbar">
         <div class="nav-container">
             <a href="index.html" class="logo">
@@ -817,11 +769,6 @@
         </div>
     </div>
 
-    <div id="chat-controls">
-        <input id="chatInput" type="text" placeholder="Describe block layout..." />
-        <button id="chatSend">Send</button>
-    </div>
-
     <script>
         // --- Global variables ---
         let droppedServices = [];
@@ -854,41 +801,6 @@
         canvas.addEventListener('dragover', handleDragOver);
         canvas.addEventListener('drop', handleDrop);
 
-        const chatInput = document.getElementById('chatInput');
-        const chatSend = document.getElementById('chatSend');
-        chatSend.addEventListener('click', sendLayoutRequest);
-        chatInput.addEventListener('keydown', e => {
-            if (e.key === 'Enter') sendLayoutRequest();
-        });
-
-        async function sendLayoutRequest() {
-            const message = chatInput.value;
-            if (!message) return;
-            try {
-                const res = await fetch('/api/layout', {
-                    method: 'POST',
-                    headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({ message })
-                });
-                const data = await res.json();
-                const moves = JSON.parse(data.instructions);
-                moves.forEach(m => {
-                    const el = document.getElementById(m.id);
-                    if (el) {
-                        el.style.left = m.x + 'px';
-                        el.style.top = m.y + 'px';
-                        const svc = droppedServices.find(s => s.id === m.id);
-                        if (svc) {
-                            svc.x = m.x;
-                            svc.y = m.y;
-                        }
-                    }
-                });
-                chatInput.value = '';
-            } catch (err) {
-                console.error('Layout request failed:', err);
-            }
-        }
 
         function handleDragStart(e) {
             e.target.classList.add('dragging');

--- a/dist/index.html
+++ b/dist/index.html
@@ -647,7 +647,7 @@
   <h2>About Meir</h2>
   <p>With over 5 years of experience in automation and development, I specialize in creating custom solutions that transform how businesses operate. My "can-do" attitude and deep expertise in Google Apps Script, Firebase, and modern web technologies enable me to tackle even the most complex challenges.
     <img id="profile_image" src="https://media.licdn.com/dms/image/v2/D4D03AQGiPqbELG4MeQ/profile-displayphoto-shrink_800_800/B4DZYFxoWJH4Ak-/0/1743853619029?e=1757548800&amp;v=beta&amp;t=eHfhFiQk9_NxOUBFMGCR-twPEu4gfoOPn9ON_vNZe5E" alt="Meir">
-    <b>Meir Horowitz <i>Automation expert at Fiverr</i></b>
+    <b>Meir Horwitz <i>Automation expert at Fiverr</i></b>
   </p>
   <div class="stats">
     <div>5<p>Years Experience</p></div>

--- a/public/automation-playground.html
+++ b/public/automation-playground.html
@@ -251,9 +251,10 @@
         /* Main Container */
         .container {
             display: flex;
-            height: 100vh;
+            height: calc(100vh - 120px);
             position: relative;
             z-index: 1;
+            margin-top: 120px;
         }
 
         /* Service Panel */
@@ -531,48 +532,7 @@
             margin-top: 0.25rem;
         }
 
-        /* Guide overlay */
-        #guide {
-            position: fixed;
-            top: 0;
-            left: 0;
-            width: 100%;
-            background: #ffffe0;
-            color: #000;
-            padding: 10px;
-            border-bottom: 1px solid #ccc;
-            z-index: 3000;
-        }
-        #guide button {
-            margin-top: 10px;
-        }
-
-        /* Chat controls */
-        #chat-controls {
-            position: fixed;
-            bottom: 20px;
-            left: 50%;
-            transform: translateX(-50%);
-            display: flex;
-            gap: 0.5rem;
-            z-index: 1100;
-        }
-        #chatInput {
-            padding: 0.5rem;
-            width: 300px;
-            border-radius: 4px;
-            border: 1px solid #444;
-            background: #2d2d30;
-            color: #fff;
-        }
-        #chatSend {
-            padding: 0.5rem 1rem;
-            background: var(--primary);
-            border: none;
-            border-radius: 4px;
-            cursor: pointer;
-            color: #000;
-        }
+        /* Chat controls removed */
 
         /* Action Buttons */
         .action-buttons {
@@ -771,14 +731,6 @@
     <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-PZ9XZMFL"
     height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
     <!-- End Google Tag Manager (noscript) -->
-    <div id="guide">
-        <h2>How to use this canvas</h2>
-        <p>
-            1. Drag service blocks onto the canvas.<br>
-            2. Type instructions in the chat below to arrange them automatically.
-        </p>
-        <button onclick="document.getElementById('guide').style.display='none'">Got it!</button>
-    </div>
     <div id="header">
       <a href="index.html"><img src="ma_logo.svg" alt="Automations by Meir" /></a>
       <nav>
@@ -909,11 +861,6 @@
         </div>
     </div>
 
-    <div id="chat-controls">
-        <input id="chatInput" type="text" placeholder="Describe block layout..." />
-        <button id="chatSend">Send</button>
-    </div>
-
     <script>
         // --- Global variables ---
         let droppedServices = [];
@@ -946,41 +893,6 @@
         canvas.addEventListener('dragover', handleDragOver);
         canvas.addEventListener('drop', handleDrop);
 
-        const chatInput = document.getElementById('chatInput');
-        const chatSend = document.getElementById('chatSend');
-        chatSend.addEventListener('click', sendLayoutRequest);
-        chatInput.addEventListener('keydown', e => {
-            if (e.key === 'Enter') sendLayoutRequest();
-        });
-
-        async function sendLayoutRequest() {
-            const message = chatInput.value;
-            if (!message) return;
-            try {
-                const res = await fetch('/api/layout', {
-                    method: 'POST',
-                    headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({ message })
-                });
-                const data = await res.json();
-                const moves = JSON.parse(data.instructions);
-                moves.forEach(m => {
-                    const el = document.getElementById(m.id);
-                    if (el) {
-                        el.style.left = m.x + 'px';
-                        el.style.top = m.y + 'px';
-                        const svc = droppedServices.find(s => s.id === m.id);
-                        if (svc) {
-                            svc.x = m.x;
-                            svc.y = m.y;
-                        }
-                    }
-                });
-                chatInput.value = '';
-            } catch (err) {
-                console.error('Layout request failed:', err);
-            }
-        }
 
         function handleDragStart(e) {
             e.target.classList.add('dragging');

--- a/public/index.html
+++ b/public/index.html
@@ -690,7 +690,7 @@
   <h2>About Meir</h2>
   <p>With over 5 years of experience in automation and development, I specialize in creating custom solutions that transform how businesses operate. My "can-do" attitude and deep expertise in Google Apps Script, Firebase, and modern web technologies enable me to tackle even the most complex challenges.
     <img id="profile_image" src="https://media.licdn.com/dms/image/v2/D4D03AQGiPqbELG4MeQ/profile-displayphoto-shrink_800_800/B4DZYFxoWJH4Ak-/0/1743853619029?e=1757548800&amp;v=beta&amp;t=eHfhFiQk9_NxOUBFMGCR-twPEu4gfoOPn9ON_vNZe5E" alt="Meir">
-    <b>Meir Horowitz <i>Automation expert at Fiverr</i></b>
+    <b>Meir Horwitz <i>Automation expert at Fiverr</i></b>
   </p>
   <div class="stats">
     <div>5<p>Years Experience</p></div>


### PR DESCRIPTION
## Summary
- Update "Meir Horowitz" to "Meir Horwitz" across site
- Fix playground layout so navigation no longer overlaps feature area
- Remove instructional popup and typing controls from playground

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_b_68a4b6d32a808333a5fb4279c41604a8