### PR TITLE
fix: prevent nav overlap on playground buttons

### DIFF
--- a/public/automation-playground.html
+++ b/public/automation-playground.html
@@ -537,7 +537,7 @@
         /* Action Buttons */
         .action-buttons {
             position: fixed;
-            top: 6rem;
+            top: 8rem;
             right: 2rem;
             display: flex;
             gap: 1rem;


### PR DESCRIPTION
## Summary
- increase spacing above action buttons on playground to clear nav bar

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68a4bb3efeb083338d8373d2fc4df7b8