### PR TITLE
Improve scheduling UI responsiveness

### DIFF
--- a/public/index-he.html
+++ b/public/index-he.html
@@ -533,7 +533,7 @@
                         <p style="color: var(--light); margin-bottom: 1rem;">כל הזמנים מוצגים באזור הזמן המקומי שלך.</p>
                         <div id="slotsLoader" class="loader" style="display: none;"></div>
                         <div id="timeSlots" class="time-slots-container"></div>
-                        <div style="margin-top: 2rem; display: flex; gap: 1rem; justify-content: center;">
+                        <div id="formButtons" style="margin-top: 2rem; display: none; gap: 1rem; justify-content: center;">
                             <button type="button" id="toStep1" class="cta-secondary">חזור</button>
                             <button type="submit" id="submitBtn" class="cta-button">שליחה וקביעת פגישה</button>
                         </div>
@@ -565,6 +565,7 @@
         const toStep1Btn = document.getElementById('toStep1');
         const form = document.getElementById('projectForm');
         const submitBtn = document.getElementById('submitBtn');
+        const formButtons = document.getElementById('formButtons');
         const slotsLoader = document.getElementById('slotsLoader');
         const timeSlotsContainer = document.getElementById('timeSlots');
         const formMessage = document.getElementById('form-message');
@@ -573,6 +574,8 @@
             if (form.checkValidity()) {
                 step1.classList.remove('active');
                 step2.classList.add('active');
+                formButtons.style.display = 'none';
+                submitBtn.style.display = '';
                 fetchAvailableSlots();
             } else {
                 form.reportValidity();
@@ -581,10 +584,12 @@
         toStep1Btn.addEventListener('click', () => {
             step2.classList.remove('active');
             step1.classList.add('active');
+            formButtons.style.display = 'none';
         });
         async function fetchAvailableSlots() {
             slotsLoader.style.display = 'block';
             timeSlotsContainer.innerHTML = '';
+            formButtons.style.display = 'none';
             try {
                 const response = await fetch(SCRIPT_URL);
                 const data = await response.json();
@@ -596,6 +601,8 @@
             } catch (error) {
                 console.error('Error fetching slots:', error);
                 timeSlotsContainer.innerHTML = `<p style="color: var(--danger);">Could not load available times. Please try again later.</p>`;
+                formButtons.style.display = 'flex';
+                submitBtn.style.display = 'none';
             } finally {
                 slotsLoader.style.display = 'none';
             }
@@ -603,6 +610,8 @@
         function displaySlots(slots) {
             if (slots.length === 0) {
                 timeSlotsContainer.innerHTML = `<p style="color: var(--light);">No available slots in the next 7 days. Please check back later.</p>`;
+                formButtons.style.display = 'flex';
+                submitBtn.style.display = 'none';
                 return;
             }
             const groupedSlots = slots.reduce((acc, slot) => {
@@ -623,6 +632,8 @@
                 });
             }
             timeSlotsContainer.innerHTML = html;
+            formButtons.style.display = 'flex';
+            submitBtn.style.display = 'inline-block';
         }
         timeSlotsContainer.addEventListener('click', (e) => {
             if (e.target.classList.contains('time-slot')) {

--- a/public/index.html
+++ b/public/index.html
@@ -586,6 +586,19 @@
       0% { transform: rotate(0deg); }
       100% { transform: rotate(360deg); }
     }
+    @media (max-width: 768px) {
+      nav {
+        width: 100%;
+        gap: 16px;
+        padding: 16px;
+        justify-content: center;
+      }
+      nav ul {
+        width: 100%;
+        align-items: center;
+        text-align: center;
+      }
+    }
   </style>
 </head>
 <body>
@@ -729,7 +742,7 @@
       <p style="color: var(--light); margin-bottom: 1rem;">All times are in your local timezone.</p>
       <div id="slotsLoader" class="loader" style="display: none;"></div>
       <div id="timeSlots" class="time-slots-container"></div>
-      <div style="margin-top: 2rem; display: flex; gap: 1rem; justify-content: center;">
+      <div id="formButtons" style="margin-top: 2rem; display: none; gap: 1rem; justify-content: center;">
         <button type="button" id="toStep1" class="button">Back</button>
         <button type="submit" id="submitBtn" class="button">Submit &amp; Schedule</button>
       </div>
@@ -893,6 +906,7 @@ document.addEventListener('DOMContentLoaded', function() {
   const toStep1Btn = document.getElementById('toStep1');
   const form = document.getElementById('projectForm');
   const submitBtn = document.getElementById('submitBtn');
+  const formButtons = document.getElementById('formButtons');
   const slotsLoader = document.getElementById('slotsLoader');
   const timeSlotsContainer = document.getElementById('timeSlots');
   const formMessage = document.getElementById('form-message');
@@ -901,6 +915,8 @@ document.addEventListener('DOMContentLoaded', function() {
     if (form.checkValidity()) {
       step1.classList.remove('active');
       step2.classList.add('active');
+      formButtons.style.display = 'none';
+      submitBtn.style.display = '';
       fetchAvailableSlots();
     } else {
       form.reportValidity();
@@ -909,10 +925,12 @@ document.addEventListener('DOMContentLoaded', function() {
   toStep1Btn.addEventListener('click', () => {
     step2.classList.remove('active');
     step1.classList.add('active');
+    formButtons.style.display = 'none';
   });
   async function fetchAvailableSlots() {
     slotsLoader.style.display = 'block';
     timeSlotsContainer.innerHTML = '';
+    formButtons.style.display = 'none';
     try {
       const response = await fetch(SCRIPT_URL);
       const data = await response.json();
@@ -924,6 +942,8 @@ document.addEventListener('DOMContentLoaded', function() {
     } catch (error) {
       console.error('Error fetching slots:', error);
       timeSlotsContainer.innerHTML = `<p style="color: var(--danger);">Could not load available times. Please try again later.</p>`;
+      formButtons.style.display = 'flex';
+      submitBtn.style.display = 'none';
     } finally {
       slotsLoader.style.display = 'none';
     }
@@ -931,6 +951,8 @@ document.addEventListener('DOMContentLoaded', function() {
   function displaySlots(slots) {
     if (slots.length === 0) {
       timeSlotsContainer.innerHTML = `<p style="color: var(--light);">No available slots in the next 7 days. Please check back later.</p>`;
+      formButtons.style.display = 'flex';
+      submitBtn.style.display = 'none';
       return;
     }
     const groupedSlots = slots.reduce((acc, slot) => {
@@ -953,6 +975,8 @@ document.addEventListener('DOMContentLoaded', function() {
     }
     html += '</tbody></table>';
     timeSlotsContainer.innerHTML = html;
+    formButtons.style.display = 'flex';
+    submitBtn.style.display = 'inline-block';
   }
   timeSlotsContainer.addEventListener('click', (e) => {
     if (e.target.classList.contains('time-slot')) {


### PR DESCRIPTION
## Summary
- Make navigation bar responsive on small screens
- Hide back/submit buttons until meeting slots load
- Apply same scheduling fixes to Hebrew index page

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68a4dd46c6088333ae09c2d3e69e1b88