### PR TITLE
Present consultation slots in table

### DIFF
--- a/dist/index-he.html
+++ b/dist/index-he.html
@@ -68,13 +68,12 @@
             background-color: #2d2d30; color: var(--light); font-size: 1rem; text-align: right;
         }
         .form-group textarea { min-height: 150px; }
-        .time-slots-container { display: grid; grid-template-columns: repeat(auto-fill, minmax(150px, 1fr)); gap: 1rem; margin-top: 1rem; }
-        .time-slot {
-            background: #2d2d30; color: var(--light); padding: 1rem; border-radius: 0;
-            border: 1px solid var(--gray); cursor: pointer; transition: all 0.2s ease; text-align: center;
+        .time-slots-table { width: 100%; border-collapse: collapse; margin-top: 1rem; }
+        .time-slots-table th, .time-slots-table td {
+            padding: .75rem 1rem; border: 1px solid var(--gray); text-align: right;
         }
-        .time-slot:hover { background: #3c3c3f; border-color: var(--primary); }
-        .time-slot.selected { background: var(--secondary); color: white; border-color: var(--secondary); }
+        .time-slots-table tr.time-slot:hover { background: #3c3c3f; cursor: pointer; }
+        .time-slots-table tr.time-slot.selected { background: var(--secondary); color: white; }
         #form-message { margin-top: 1rem; padding: 1rem; border-radius: 0; text-align: center; display: none; }
         #form-message.success { background-color: rgba(52, 168, 83, 0.2); color: var(--secondary); }
         #form-message.error { background-color: rgba(234, 67, 53, 0.2); color: var(--danger); }
@@ -442,7 +441,7 @@
                         <h3>בחרו מועד לפגישת ייעוץ של 30 דקות</h3>
                         <p style="color: var(--light); margin-bottom: 1rem;">כל הזמנים מוצגים באזור הזמן המקומי שלך.</p>
                         <div id="slotsLoader" class="loader" style="display: none;"></div>
-                        <div id="timeSlots" class="time-slots-container"></div>
+                          <div id="timeSlots"></div>
                         <div style="margin-top: 2rem; display: flex; gap: 1rem; justify-content: center;">
                             <button type="button" id="toStep1" class="cta-secondary">חזור</button>
                             <button type="submit" id="submitBtn" class="cta-button">שליחה וקביעת פגישה</button>
@@ -515,30 +514,27 @@
                 timeSlotsContainer.innerHTML = `<p style="color: var(--light);">No available slots in the next 7 days. Please check back later.</p>`;
                 return;
             }
-            const groupedSlots = slots.reduce((acc, slot) => {
-                const date = new Date(slot);
-                const day = date.toLocaleDateString('he-IL', { weekday: 'long', month: 'long', day: 'numeric' });
-                if (!acc[day]) {
-                    acc[day] = [];
-                }
-                acc[day].push(slot);
-                return acc;
-            }, {});
-            let html = '';
-            for (const day in groupedSlots) {
-                html += `<div style="grid-column: 1 / -1;"><h4 style="color: var(--accent); margin-top: 1rem;">${day}</h4></div>`;
-                groupedSlots[day].forEach(slotISO => {
-                    const time = new Date(slotISO).toLocaleTimeString('he-IL', { hour: '2-digit', minute: '2-digit', hour12: false });
-                    html += `<div class="time-slot" data-value="${slotISO}">${time}</div>`;
-                });
-            }
-            timeSlotsContainer.innerHTML = html;
+            let rows = '';
+            slots.forEach(slotISO => {
+                const dateObj = new Date(slotISO);
+                const day = dateObj.toLocaleDateString('he-IL', { weekday: 'long', month: 'long', day: 'numeric' });
+                const time = dateObj.toLocaleTimeString('he-IL', { hour: '2-digit', minute: '2-digit', hour12: false });
+                rows += `<tr class="time-slot" data-value="${slotISO}"><td>${day}</td><td>${time}</td></tr>`;
+            });
+            timeSlotsContainer.innerHTML = `
+                <table class="time-slots-table">
+                    <thead>
+                        <tr><th>תאריך</th><th>שעה</th></tr>
+                    </thead>
+                    <tbody>${rows}</tbody>
+                </table>`;
         }
         timeSlotsContainer.addEventListener('click', (e) => {
-            if (e.target.classList.contains('time-slot')) {
+            const row = e.target.closest('.time-slot');
+            if (row) {
                 document.querySelectorAll('.time-slot').forEach(slot => slot.classList.remove('selected'));
-                e.target.classList.add('selected');
-                selectedSlot = e.target.dataset.value;
+                row.classList.add('selected');
+                selectedSlot = row.dataset.value;
             }
         });
         form.addEventListener('submit', async (e) => {

--- a/dist/index.html
+++ b/dist/index.html
@@ -494,29 +494,23 @@
     }
     .form-step { display: none; }
     .form-step.active { display: block; }
-    .time-slots-container {
-      display: grid;
-      grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
-      gap: 1rem;
+    .time-slots-table {
+      width: 100%;
+      border-collapse: collapse;
       margin-top: 1rem;
     }
-    .time-slot {
-      background: #100F0F;
-      color: var(--light);
-      padding: 1rem;
-      border-radius: 8px;
+    .time-slots-table th,
+    .time-slots-table td {
+      padding: .5rem 1rem;
       border: 1px solid var(--border-color);
-      cursor: pointer;
-      transition: all 0.2s ease;
-      text-align: center;
+      text-align: left;
     }
-    .time-slot:hover {
+    .time-slots-table tr.time-slot:hover {
       background: #161616;
-      border-color: var(--primary);
+      cursor: pointer;
     }
-    .time-slot.selected {
+    .time-slots-table tr.time-slot.selected {
       background: var(--secondary);
-      border-color: var(--secondary);
       color: var(--light);
     }
     #form-message {
@@ -685,7 +679,7 @@
       <h3>Select a Time for a 30-Minute Consultation</h3>
       <p style="color: var(--light); margin-bottom: 1rem;">All times are in your local timezone.</p>
       <div id="slotsLoader" class="loader" style="display: none;"></div>
-      <div id="timeSlots" class="time-slots-container"></div>
+      <div id="timeSlots"></div>
       <div style="margin-top: 2rem; display: flex; gap: 1rem; justify-content: center;">
         <button type="button" id="toStep1" class="button">Back</button>
         <button type="submit" id="submitBtn" class="button">Submit &amp; Schedule</button>
@@ -890,30 +884,27 @@ document.addEventListener('DOMContentLoaded', function() {
       timeSlotsContainer.innerHTML = `<p style="color: var(--light);">No available slots in the next 7 days. Please check back later.</p>`;
       return;
     }
-    const groupedSlots = slots.reduce((acc, slot) => {
-      const date = new Date(slot);
-      const day = date.toLocaleDateString(undefined, { weekday: 'long', month: 'long', day: 'numeric' });
-      if (!acc[day]) {
-        acc[day] = [];
-      }
-      acc[day].push(slot);
-      return acc;
-    }, {});
-    let html = '';
-    for (const day in groupedSlots) {
-      html += `<div style="grid-column: 1 / -1;"><h4 style="color: var(--accent); margin-top: 1rem;">${day}</h4></div>`;
-      groupedSlots[day].forEach(slotISO => {
-        const time = new Date(slotISO).toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit', hour12: false });
-        html += `<div class="time-slot" data-value="${slotISO}">${time}</div>`;
-      });
-    }
-    timeSlotsContainer.innerHTML = html;
+    let rows = '';
+    slots.forEach(slotISO => {
+      const dateObj = new Date(slotISO);
+      const day = dateObj.toLocaleDateString(undefined, { weekday: 'long', month: 'long', day: 'numeric' });
+      const time = dateObj.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit', hour12: false });
+      rows += `<tr class="time-slot" data-value="${slotISO}"><td>${day}</td><td>${time}</td></tr>`;
+    });
+    timeSlotsContainer.innerHTML = `
+      <table class="time-slots-table">
+        <thead>
+          <tr><th>Date</th><th>Time</th></tr>
+        </thead>
+        <tbody>${rows}</tbody>
+      </table>`;
   }
   timeSlotsContainer.addEventListener('click', (e) => {
-    if (e.target.classList.contains('time-slot')) {
-      document.querySelectorAll('.time-slot').forEach(slot => slot.classList.remove('selected'));
-      e.target.classList.add('selected');
-      selectedSlot = e.target.dataset.value;
+    const row = e.target.closest('.time-slot');
+    if (row) {
+      timeSlotsContainer.querySelectorAll('.time-slot').forEach(slot => slot.classList.remove('selected'));
+      row.classList.add('selected');
+      selectedSlot = row.dataset.value;
     }
   });
   form.addEventListener('submit', async (e) => {

--- a/public/index-he.html
+++ b/public/index-he.html
@@ -68,13 +68,12 @@
             background-color: #2d2d30; color: var(--light); font-size: 1rem; text-align: right;
         }
         .form-group textarea { min-height: 150px; }
-        .time-slots-container { display: grid; grid-template-columns: repeat(auto-fill, minmax(150px, 1fr)); gap: 1rem; margin-top: 1rem; }
-        .time-slot {
-            background: #2d2d30; color: var(--light); padding: 1rem; border-radius: 0;
-            border: 1px solid var(--gray); cursor: pointer; transition: all 0.2s ease; text-align: center;
+        .time-slots-table { width: 100%; border-collapse: collapse; margin-top: 1rem; }
+        .time-slots-table th, .time-slots-table td {
+            padding: .75rem 1rem; border: 1px solid var(--gray); text-align: right;
         }
-        .time-slot:hover { background: #3c3c3f; border-color: var(--primary); }
-        .time-slot.selected { background: var(--secondary); color: white; border-color: var(--secondary); }
+        .time-slots-table tr.time-slot:hover { background: #3c3c3f; cursor: pointer; }
+        .time-slots-table tr.time-slot.selected { background: var(--secondary); color: white; }
         #form-message { margin-top: 1rem; padding: 1rem; border-radius: 0; text-align: center; display: none; }
         #form-message.success { background-color: rgba(52, 168, 83, 0.2); color: var(--secondary); }
         #form-message.error { background-color: rgba(234, 67, 53, 0.2); color: var(--danger); }
@@ -715,7 +714,7 @@ nav {
                         <h3>בחרו מועד לפגישת ייעוץ של 30 דקות</h3>
                         <p style="color: var(--light); margin-bottom: 1rem;">כל הזמנים מוצגים באזור הזמן המקומי שלך.</p>
                         <div id="slotsLoader" class="loader" style="display: none;"></div>
-                        <div id="timeSlots" class="time-slots-container"></div>
+                          <div id="timeSlots"></div>
                         <div id="formButtons" style="margin-top: 2rem; display: none; gap: 1rem; justify-content: center;">
                             <button type="button" id="toStep1" class="cta-secondary">חזור</button>
                             <button type="submit" id="submitBtn" class="cta-button">שליחה וקביעת פגישה</button>
@@ -797,32 +796,29 @@ nav {
                 submitBtn.style.display = 'none';
                 return;
             }
-            const groupedSlots = slots.reduce((acc, slot) => {
-                const date = new Date(slot);
-                const day = date.toLocaleDateString('he-IL', { weekday: 'long', month: 'long', day: 'numeric' });
-                if (!acc[day]) {
-                    acc[day] = [];
-                }
-                acc[day].push(slot);
-                return acc;
-            }, {});
-            let html = '';
-            for (const day in groupedSlots) {
-                html += `<div style="grid-column: 1 / -1;"><h4 style="color: var(--accent); margin-top: 1rem;">${day}</h4></div>`;
-                groupedSlots[day].forEach(slotISO => {
-                    const time = new Date(slotISO).toLocaleTimeString('he-IL', { hour: '2-digit', minute: '2-digit', hour12: false });
-                    html += `<div class="time-slot" data-value="${slotISO}">${time}</div>`;
-                });
-            }
-            timeSlotsContainer.innerHTML = html;
+            let rows = '';
+            slots.forEach(slotISO => {
+                const dateObj = new Date(slotISO);
+                const day = dateObj.toLocaleDateString('he-IL', { weekday: 'long', month: 'long', day: 'numeric' });
+                const time = dateObj.toLocaleTimeString('he-IL', { hour: '2-digit', minute: '2-digit', hour12: false });
+                rows += `<tr class="time-slot" data-value="${slotISO}"><td>${day}</td><td>${time}</td></tr>`;
+            });
+            timeSlotsContainer.innerHTML = `
+                <table class="time-slots-table">
+                    <thead>
+                        <tr><th>תאריך</th><th>שעה</th></tr>
+                    </thead>
+                    <tbody>${rows}</tbody>
+                </table>`;
             formButtons.style.display = 'flex';
             submitBtn.style.display = 'inline-block';
         }
         timeSlotsContainer.addEventListener('click', (e) => {
-            if (e.target.classList.contains('time-slot')) {
+            const row = e.target.closest('.time-slot');
+            if (row) {
                 document.querySelectorAll('.time-slot').forEach(slot => slot.classList.remove('selected'));
-                e.target.classList.add('selected');
-                selectedSlot = e.target.dataset.value;
+                row.classList.add('selected');
+                selectedSlot = row.dataset.value;
             }
         });
         form.addEventListener('submit', async (e) => {

--- a/public/index.html
+++ b/public/index.html
@@ -503,32 +503,26 @@
         display: flex;
       }
 
-      .time-slots-container {
-        display: grid;
-        grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
-        gap: 1rem;
+      .time-slots-table {
+        width: 100%;
+        border-collapse: collapse;
         margin-top: 1rem;
       }
 
-      .time-slot {
-        background: #100F0F;
-        color: var(--light);
+      .time-slots-table th,
+      .time-slots-table td {
         padding: 0.5rem 1rem;
-        border-radius: 8px;
         border: 1px solid var(--border-color);
-        cursor: pointer;
-        transition: all 0.2s ease;
-        text-align: center;
+        text-align: left;
       }
 
-      .time-slot:hover {
+      .time-slots-table tr.time-slot:hover {
         background: #161616;
-        border-color: var(--primary);
+        cursor: pointer;
       }
 
-      .time-slot.selected {
+      .time-slots-table tr.time-slot.selected {
         background: var(--secondary);
-        border-color: var(--secondary);
         color: var(--light);
       }
 
@@ -780,7 +774,7 @@
               <h3>Select a Time for a 30-Minute Consultation</h3>
               <p style="color: var(--light); margin-bottom: 1rem;">All times are in your local timezone.</p>
               <div id="slotsLoader" class="loader" style="display: none;"></div>
-              <div id="timeSlots" class="time-slots-container"></div>
+                <div id="timeSlots"></div>
               <div style="margin-top: 2rem; display: flex; gap: 1rem; justify-content: center;">
                   <button type="button" id="toStep1" class="btn btn-secondary">Back</button>
                   <button type="submit" id="submitBtn" class="btn btn-primary">Submit &amp; Schedule</button>
@@ -1045,30 +1039,31 @@
       return;
     }
 
-    const groupedSlots = slots.reduce((acc, slot) => {
-      const date = new Date(slot);
-      const day = date.toLocaleDateString(undefined, { weekday: "long", month: "long", day: "numeric" });
-      if (!acc[day]) acc[day] = [];
-      acc[day].push(slot);
-      return acc;
-    }, {});
+    let rows = "";
+    slots.forEach((slotISO) => {
+      const dateObj = new Date(slotISO);
+      const date = dateObj.toLocaleDateString(undefined, { weekday: "long", month: "long", day: "numeric" });
+      const time = dateObj.toLocaleTimeString(undefined, { hour: "2-digit", minute: "2-digit", hour12: false });
+      rows += `<tr class=\"time-slot\" data-value=\"${slotISO}\"><td>${date}</td><td>${time}</td></tr>`;
+    });
 
-    let html = "";
-    for (const day in groupedSlots) {
-      html += `<div style="grid-column: 1 / -1;"><h4 style=\"color: var(--accent); margin-top: 1rem;\">${day}</h4></div>`;
-      groupedSlots[day].forEach((slotISO) => {
-        const time = new Date(slotISO).toLocaleTimeString(undefined, { hour: "2-digit", minute: "2-digit", hour12: false });
-        html += `<div class=\"time-slot\" data-value=\"${slotISO}\">${time}</div>`;
-      });
-    }
-    timeSlotsContainer.innerHTML = html;
+    timeSlotsContainer.innerHTML = `
+      <table class=\"time-slots-table\">
+        <thead>
+          <tr><th>Date</th><th>Time</th></tr>
+        </thead>
+        <tbody>${rows}</tbody>
+      </table>`;
   }
 
   timeSlotsContainer.addEventListener("click", (e) => {
-    if (e.target.classList.contains("time-slot")) {
-      document.querySelectorAll(".time-slot").forEach((slot) => slot.classList.remove("selected"));
-      e.target.classList.add("selected");
-      selectedSlot = e.target.dataset.value;
+    const row = e.target.closest(".time-slot");
+    if (row) {
+      timeSlotsContainer
+        .querySelectorAll(".time-slot")
+        .forEach((slot) => slot.classList.remove("selected"));
+      row.classList.add("selected");
+      selectedSlot = row.dataset.value;
     }
   });
 


### PR DESCRIPTION
## Summary
- Lay out time-slot picker as a two-column table for easier review
- Support new table layout in both English and Hebrew pages

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_68a633e1233083339cf76f2f6c94b578