### PR TITLE
Add static sitemap for Firebase hosting

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url><loc>https://automationbymeir.web.app/</loc></url>
+  <url><loc>https://automationbymeir.web.app/index.html</loc></url>
+  <url><loc>https://automationbymeir.web.app/index-he.html</loc></url>
+  <url><loc>https://automationbymeir.web.app/automation-playground.html</loc></url>
+  <url><loc>https://automationbymeir.web.app/payment.html</loc></url>
+  <url><loc>https://automationbymeir.web.app/showcase1.html</loc></url>
+  <url><loc>https://automationbymeir.web.app/showcase2.html</loc></url>
+  <url><loc>https://automationbymeir.web.app/showcase-job-post-pro.html</loc></url>
+  <url><loc>https://automationbymeir.web.app/why-automation.html</loc></url>
+  <url><loc>https://automationbymeir.web.app/why-automation-he.html</loc></url>
+  <url><loc>https://automationbymeir.web.app/about-me.html</loc></url>
+  <url><loc>https://automationbymeir.web.app/about-me-he.html</loc></url>
+  <url><loc>https://automationbymeir.web.app/services/ai-powered-systems.html</loc></url>
+  <url><loc>https://automationbymeir.web.app/services/api-integration.html</loc></url>
+  <url><loc>https://automationbymeir.web.app/services/process-automation.html</loc></url>
+  <url><loc>https://automationbymeir.web.app/services/document-generation.html</loc></url>
+  <url><loc>https://automationbymeir.web.app/services/web-development.html</loc></url>
+  <url><loc>https://automationbymeir.web.app/services/data-dashboards.html</loc></url>
+</urlset>


### PR DESCRIPTION
## Summary
- add static sitemap.xml listing all site pages so Firebase hosting returns sitemap instead of 404

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_68a9b7dcaca48333bffd5e6211534683