### PR TITLE
Update profile image to new SVG asset

### DIFF
--- a/public/index-he.html
+++ b/public/index-he.html
@@ -660,7 +660,7 @@ nav {
             <div class="about-content">
                 <div class="about-header">
                     <div class="profile-photo">
-                        <img src="https://media.licdn.com/dms/image/v2/D4D03AQGiPqbELG4MeQ/profile-displayphoto-shrink_800_800/B4DZYFxoWJH4Ak-/0/1743853619029?e=1757548800&v=beta&t=eHfhFiQk9_NxOUBFMGCR-twPEu4gfoOPn9ON_vNZe5E" alt="Meir" />
+                        <img src="logos/profilepicture.svg" alt="Meir" />
                     </div>
                     <div>
                         <p class="about-text">

--- a/public/index.html
+++ b/public/index.html
@@ -731,7 +731,7 @@
     <h2>About Meir</h2>
         
         <p>With over 5 years of experience in automation and development, I specialize in creating custom solutions that transform how businesses operate. My "can-do" attitude and deep expertise in Google Apps Script, Firebase, and modern web technologies enable me to tackle even the most complex challenges.
-          <img id="profile_image" src="https://media.licdn.com/dms/image/v2/D4D03AQGiPqbELG4MeQ/profile-displayphoto-shrink_800_800/B4DZYFxoWJH4Ak-/0/1743853619029?e=1757548800&amp;v=beta&amp;t=eHfhFiQk9_NxOUBFMGCR-twPEu4gfoOPn9ON_vNZe5E" alt="Meir">
+          <img id="profile_image" src="logos/profilepicture.svg" alt="Meir">
           <b>Meir Horwitz <i>Automation expert at Fiverr</i></b>
         </p>
         <div class="stats">


### PR DESCRIPTION
## Summary
- replace the externally hosted profile photo on the English and Hebrew landing pages with the new SVG stored at `public/logos/profilepicture.svg`.

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68e2140bbb688333b97774034c9e4ebf